### PR TITLE
Use HTTPS URL for :Gbrowse

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1491,7 +1491,7 @@ function! s:github_url(repo,url,rev,commit,path,type,line1,line2) abort
   if repo_path ==# ''
     return ''
   endif
-  let root = 'http://github.com/' . repo_path
+  let root = 'https://github.com/' . repo_path
   if path =~# '^\.git/refs/heads/'
     let branch = a:repo.git_chomp('config','branch.'.path[16:-1].'.merge')[11:-1]
     if branch ==# ''


### PR DESCRIPTION
The `:Gbrowse` command uses a GitHub URL using the http protocol. Hitting such a URL causes a redirect to the equivalent page using https. However, the hash, containing a line range, is lost in this redirect. This patch changes fugitive to use https, so there is no redirect and line information is retained. 
