### PR TITLE
fileformat not set properly on Windows

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1652,7 +1652,15 @@ function! s:ReplaceCmd(cmd,...) abort
         let prefix = 'env GIT_INDEX_FILE='.s:shellesc(a:1).' '
       endif
     endif
-    call writefile(split(system(prefix.a:cmd), "\n", 1), tmp, 'b')
+    let lines = []
+    if has('win32') || has('win64')
+      for line in split(system(prefix.a:cmd), "\n", 1))
+        call add(lines, line."\r")
+      endfor
+    else
+      lines = split(system(prefix.a:cmd), "\n", 1))
+    endif
+    call writefile(lines, tmp, 'b')
   finally
     if exists('old_index')
       let $GIT_INDEX_FILE = old_index


### PR DESCRIPTION
I'm using fugitive in Gvim 7.3 on Windows 7, in a repository with `autocrlf=false` -- meaning that we use CRLF endings in the repository. When fugitive opens up an index buffer (via e.g. `:Gdiff`) it has `ff=unix` set, meaning that the diffs get a little messy trying to add or reset hunks. Is this a known issue, or is there a workaround I'm missing to properly register this with fugitive?
