### PR TITLE
working mockup of 'p' and '!' support for preview-window blaming

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -170,9 +170,11 @@ that are part of Git repositories).
                         gq    q, then |:Gedit| to return to work tree version
                         i     q, then open commit
                         o     open commit in horizontal split
+                        p     open commit in horizontal preview window split
                         O     open commit in new tab
                         <CR>  reblame at commit
                         ~     reblame at [count]th first grandparent
+                        !     reblame at commit and show preview window
                         P     reblame at [count]th parent (like HEAD^[count])
 
 :[range]Gblame [flags]  Run git-blame on the given range.

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1493,6 +1493,8 @@ function! s:Blame(bang,line1,line2,count,args) abort
         nnoremap <buffer> <silent> ~    :<C-U>exe <SID>BlameJump('~'.v:count1)<CR>
         nnoremap <buffer> <silent> i    :<C-U>exe <SID>BlameCommit("exe 'norm q'<Bar>edit")<CR>
         nnoremap <buffer> <silent> o    :<C-U>exe <SID>BlameCommit((&splitbelow ? "botright" : "topleft")." split")<CR>
+        nnoremap <buffer> <silent> p    :<C-U>exe <SID>BlameCommit((&splitbelow ? "botright" : "topleft")." pedit")<CR>
+        nnoremap <buffer> <silent> !    :<C-U>exe <SID>BlameCommit((&splitbelow ? "botright" : "topleft")." pedit")<CR> <Bar> :<C-U>exe <SID>BlameJump('~'.v:count1)<CR>
         nnoremap <buffer> <silent> O    :<C-U>exe <SID>BlameCommit("tabedit")<CR>
         redraw
         syncbind
@@ -1519,6 +1521,9 @@ function! s:BlameCommit(cmd) abort
     let path = s:buffer(b:fugitive_blamed_bufnr).path()
   endif
   execute cmd
+  if cmd =~# 'pedit'
+    wincmd P
+  endif
   if search('^diff .* b/\M'.escape(path,'\').'$','W')
     call search('^+++')
     let head = line('.')
@@ -1540,11 +1545,17 @@ function! s:BlameCommit(cmd) abort
             let offset -= 1
           endif
         endwhile
+        if cmd =~# 'pedit'
+          wincmd p
+        endif
         return ''
       endif
     endwhile
     execute head
     normal! zt
+  endif
+  if cmd =~# 'pedit'
+    wincmd p
   endif
   return ''
 endfunction


### PR DESCRIPTION
related to github issue #112 make it more comfortable to walk through long
stretches of history in a :Gblame window by adding preview window support
via "p" and adding "!" which combines "~" with opening the preview commit.

---

code is a little ghetto since I don't trust myself to refactor vim-script but at least this is a low-friction way for you to try the idea.

repeated uses of 'p' in a :Gblame window feels pretty good, and the parity between `~` and `!` also feels pretty comfortable.
