### PR TITLE
Refactor fugitive#statusline()

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -262,6 +262,14 @@ a statusline, this one matches the default when 'ruler' is set:
 >
     set statusline=%<%f\ %h%m%r%{fugitive#statusline()}%=%-14.(%l,%c%V%)\ %P
 <
+                                                *fugitive#head(len)*
+Use fugitive#head() to return the name of the current branch. If the current
+HEAD is detached, fugitive#head() will return the empty string, unless the
+optional 'len' argument is given, in which case the hash of the current HEAD
+will be truncated to 'len' characters. 
+>
+    set statusline=%<%f\ %h%m%r\ branch:\ %{fugitive#head(7)}%=%-14.(%l,%c%V%)\ %P
+<
 ABOUT                                           *fugitive-about*
 
 Grab the latest version or report a bug on GitHub:

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -242,7 +242,21 @@ function! s:repo_translate(spec) dict abort
   endif
 endfunction
 
-call s:add_methods('repo',['dir','tree','bare','translate'])
+function! s:repo_head(...) dict abort
+    let head = s:repo().head_ref()
+
+    if head =~# '^ref: '
+      let branch = s:sub(head,'^ref: %(refs/%(heads/|remotes/|tags/)=)=','')
+    elseif head =~# '^\x\{40\}$'
+      " truncate hash to a:1 characters if we're in detached head mode
+      let len = a:0 ? a:1 : 0 
+      let branch = len ? head[0:len-1] : ''
+    endif
+
+    return branch
+endfunction
+
+call s:add_methods('repo',['dir','tree','bare','translate','head'])
 
 function! s:repo_git_command(...) dict abort
   let git = g:fugitive_git_executable . ' --git-dir='.s:shellesc(self.git_dir)
@@ -2288,6 +2302,15 @@ function! fugitive#statusline(...)
   else
     return '[Git'.status.']'
   endif
+endfunction
+
+function! fugitive#head(...)
+  if !exists('b:git_dir')
+    return ''
+  endif
+
+  let len = join(a:000, '')
+  return s:repo().head(len)
 endfunction
 
 " }}}1


### PR DESCRIPTION
Added fugitive#branchname() which more adventurous statusline tweakers can use instead of fugitive#statusline().
