### PR TITLE
Retain original alternate buffer when invoking :Gblame

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1483,7 +1483,7 @@ function! s:Blame(bang,line1,line2,count,args) abort
         let top = line('w0') + &scrolloff
         let current = line('.')
         let s:temp_files[temp] = s:repo().dir()
-        exe 'leftabove vsplit '.temp
+        exe 'keepalt leftabove vsplit '.temp
         let b:fugitive_blamed_bufnr = bufnr
         let w:fugitive_leave = restore
         let b:fugitive_blame_arguments = join(a:args,' ')


### PR DESCRIPTION
I frequently use vim's `<C-^>` command to switch to the alternate buffer. When using fugitive, I often find myself mildly irritated by the fact that `:Gblame` resets the alternate buffer to the temporary buffer that it creates. The effect of this is that, following a `:Gblame` invocation (after which I close the blame window), `<C-^>` switches me to the previously closed blame buffer instead of the buffer that was the alternate before fugitive changed it.

This patch simply teaches `:Gblame` to split a window for its temp buffer using Vim's `:keepalt` command as a prefix, causing it to retain the existing alternate buffer instead of changing it.
