### PR TITLE
Ignoring whitespace changes in git blame

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1435,7 +1435,7 @@ function! s:Blame(bang,line1,line2,count,args) abort
       call s:throw('unsupported option')
     endif
     call map(a:args,'s:sub(v:val,"^\\ze[^-]","-")')
-    let cmd = ['--no-pager', 'blame', '--show-number'] + a:args
+    let cmd = ['--no-pager', 'blame', '--show-number', '-w'] + a:args
     if s:buffer().commit() =~# '\D\|..'
       let cmd += [s:buffer().commit()]
     else


### PR DESCRIPTION
When a user changes tabs to spaces and commits that, he has effectively
taken over that line. `git blame -w` ignores that whitespace change and
shows the name of the person that committed before it.
