### PR TITLE
setlocal nomodeline on fugitive buffers

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -138,7 +138,6 @@ function! s:Detect(path)
     endif
   endif
   if exists('b:git_dir')
-    setlocal nomodeline
     silent doautocmd User Fugitive
     cnoremap <expr> <buffer> <C-R><C-G> <SID>recall()
     let buffer = fugitive#buffer()


### PR DESCRIPTION
When I do a :Gedit XXXX where XXXX is a commit with a diff that shows a modeline-like string (say, an option that does not exists) vim complains.
The same happens when reading the index.
I wasn't able to hook into the Fugitive User event to call setlocal nomodeline.
