### PR TITLE
Support more git index locations

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2090,8 +2090,7 @@ endfunction
 
 augroup fugitive_files
   autocmd!
-  autocmd BufReadCmd  *.git/index                      exe s:BufReadIndex()
-  autocmd BufReadCmd  *.git/*index*.lock               exe s:BufReadIndex()
+  autocmd BufReadCmd  *.git/{,**/}index{,.lock}        exe s:BufReadIndex()
   autocmd FileReadCmd fugitive://**//[0-3]/**          exe s:FileRead()
   autocmd BufReadCmd  fugitive://**//[0-3]/**          exe s:BufReadIndexFile()
   autocmd BufWriteCmd fugitive://**//[0-3]/**          exe s:BufWriteIndexFile()


### PR DESCRIPTION
Matches:

```
.git/index
.git/index.lock
.git/modules/submodule/index
.git/modules/submodule/index.lock
```
