### PR TITLE
[BUG] wildignore breaks Gdiff

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1360,9 +1360,9 @@ function! s:Diff(bang,...)
     let spec = s:repo().translate(file)
     let commit = matchstr(spec,'\C[^:/]//\zs\x\+')
     if s:buffer().compare_age(commit) < 0
-      execute 'rightbelow '.split.' `=spec`'
+      execute 'rightbelow '.split.' '.s:fnameescape(spec)
     else
-      execute 'leftabove '.split.' `=spec`'
+      execute 'leftabove '.split.' '.s:fnameescape(spec)
     endif
     call s:diffthis()
     wincmd p


### PR DESCRIPTION
When the file you're editing matches the vim variable wildignore
Gdiff fails.  This line wasn't being triggered:

autocmd BufReadCmd  fugitive://*_//[0-9a-f][0-9a-f]_ exe s:BufReadObject()
