### PR TITLE
make fugitive commands available in nerdtree bufs

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -162,6 +162,7 @@ augroup fugitive
   autocmd!
   autocmd BufNewFile,BufReadPost * call s:Detect(expand('<amatch>:p'))
   autocmd FileType           netrw call s:Detect(expand('<afile>:p'))
+  autocmd User NERDTreeInit,NERDTreeNewRoot call s:Detect(b:NERDTreeRoot.path.str())
   autocmd VimEnter * if expand('<amatch>')==''|call s:Detect(getcwd())|endif
   autocmd BufWinLeave * execute getwinvar(+bufwinnr(+expand('<abuf>')), 'fugitive_leave')
 augroup END


### PR DESCRIPTION
Previously s:Detect() wasnt getting called for nerdtree buffers. I have added two autocmd events to nerdtree - NERDTreeInit and NERDTreeNewRoot. These are called when a tree is created, and when the user changes the root.

Catch these events and call s:Detect() with the tree root path.
