### PR TITLE
[BUG] wildignore breaks Gwrite

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1205,7 +1205,7 @@ function! s:Write(force,...) abort
         try
           let lnum = line('.')
           let last = line('$')
-          silent $read `=file`
+	  silent execute '$read '.s:fnameescape(file)
           silent execute '1,'.last.'delete_'
           silent execute lnum
           set nomodified


### PR DESCRIPTION
When the file you're editing matches the vim variable
wildignore Gwrite fails.

There are a few more occurences of `=variable`, but they either refer to directories or git objects.
They're unlikely to match someone's ignorelist.
