### PR TITLE
vim modeline confuses slow programmers

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2359,4 +2359,4 @@ endfunction
 
 " }}}1
 
-" vim:set ft=vim ts=8 sw=2 sts=2:
+" vim:set ft=vim ts=8 et sw=2 sts=2:


### PR DESCRIPTION
Adding 'expandtab' (et) to the modeline prevents whitespace nightmares.
