### PR TITLE
worktree in config could also be a relative path.

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -215,7 +215,12 @@ function! s:repo_tree(...) dict abort
   if self.dir() =~# '/\.git$'
     let dir = self.dir()[0:-6]
   else
-    let dir = self.configured_tree()
+    let worktree = self.configured_tree()
+    if worktree =~#'^/' || worktree =~#'^\\'
+      let dir = worktree
+    else
+      let dir = join([self.dir(), worktree], '/')
+    endif
   endif
   if dir ==# ''
     call s:throw('no work tree')


### PR DESCRIPTION
This was found during testing the fix for issue #201.
My submodule's worktree is a relative path like "../../../sub".
Hope this fix can handle the window path as well.
