### PR TITLE
Fix jumping to a copied file from the status window.

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2251,6 +2251,9 @@ function! s:GF(mode) abort
         let file = ':'.s:sub(matchstr(getline('.'),'\d\t.*'),'\t',':')
         return s:Edit(a:mode,0,file)
 
+      elseif getline('.') =~# '^#\tcopied:.* -> '
+        let file = '/'.matchstr(getline('.'),' -> \zs.*')
+        return s:Edit(a:mode,0,file)
       elseif getline('.') =~# '^#\trenamed:.* -> '
         let file = '/'.matchstr(getline('.'),' -> \zs.*')
         return s:Edit(a:mode,0,file)


### PR DESCRIPTION
Looks like the case where a file was "copied" was not covered in the mappings
for how jumps are handled.  I simply copied the one for renamed.
