### PR TITLE
Fixed an issue for overriden blame.date

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1548,6 +1548,9 @@ function! s:Blame(bang,line1,line2,count,args) abort
     else
       let cmd += ['--contents', '-']
     endif
+    if s:repo().config('blame.date') !~# '\v^(iso|short)$'
+      let cmd += ['--date', 'iso']
+    endif
     let basecmd = escape(call(s:repo().git_command,cmd+['--',s:buffer().path()],s:repo()),'!')
     try
       let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '


### PR DESCRIPTION
If blame.date is configured to be anything except iso or short, the patterns will not match and the vertical split will be one column wide.
