### PR TITLE
Return to correct window when closing Gblame window

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1599,8 +1599,8 @@ function! s:Blame(bang,line1,line2,count,args) abort
         if exists('+relativenumber')
           setlocal norelativenumber
         endif
-        nnoremap <buffer> <silent> q    :exe substitute('bdelete<Bar>'.bufwinnr(b:fugitive_blamed_bufnr).' wincmd w','<Bar>-1','','')<CR>
-        nnoremap <buffer> <silent> gq   :exe substitute('bdelete<Bar>'.bufwinnr(b:fugitive_blamed_bufnr).' wincmd w<Bar>if expand("%:p") =~# "^fugitive:[\\/][\\/]"<Bar>Gedit<Bar>endif','<Bar>-1','','')<CR>
+        nnoremap <buffer> <silent> q    :exe substitute(bufwinnr(b:fugitive_blamed_bufnr).' wincmd w<Bar>'.bufnr('').'bdelete','^-1','','')<CR>
+        nnoremap <buffer> <silent> gq   :exe substitute(bufwinnr(b:fugitive_blamed_bufnr).' wincmd w<Bar>'.bufnr('').'bdelete<Bar>if expand("%:p") =~# "^fugitive:[\\/][\\/]"<Bar>Gedit<Bar>endif','^-1','','')<CR>
         nnoremap <buffer> <silent> <CR> :<C-U>exe <SID>BlameJump('')<CR>
         nnoremap <buffer> <silent> -    :<C-U>exe <SID>BlameJump('')<CR>
         nnoremap <buffer> <silent> P    :<C-U>exe <SID>BlameJump('^'.v:count1)<CR>


### PR DESCRIPTION
Vim does not guarantee persistent window numbers. Instead, windows are
numbered according to their position on the screen, with the topmost,
leftmost window always having number 1, and the bottommost, rightmost
window always having a number equal to the total number of windows
currently visible. Crucially, this means that, when a window is closed,
windows which come "after" it in the positional order will be
renumbered.

When fugitive's Gblame window is closed, e.g. by pressing `q`, it
attempts to return focus to the window of the blamed buffer. Previously,
the number of the window to return to was computed before closing the
Gblame window, then the Gblame window was closed, then the blamed
buffer's window was focused. However, since windows were often
renumbered as soon as the Gblame window was closed, this would
frequently cause focus to jump to the window _after_ the blamed buffer's
window, rather than the intended behavior.

This corrects the issue by jumping to the proper return window prior to
deleting the Gblame buffer, ensuring that the computed window number is
in fact correct at the moment when the focus change occurs.
