### PR TITLE
Fix Vim filename escaping for StageDiff + more

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -742,13 +742,13 @@ function! s:StageDiff(diff) abort
     return 'Git! diff'
   elseif filename =~# ' -> '
     let [old, new] = split(filename,' -> ')
-    execute 'Gedit '.s:fnameescape(':0:'.new)
+    call s:Edit('edit',0,s:fnameescape(:0:.new))
     return a:diff.' HEAD:'.s:fnameescape(old)
   elseif section ==# 'staged'
-    execute 'Gedit '.s:fnameescape(':0:'.filename)
+    call s:Edit('edit',0,s:fnameescape(':0:'.filename))
     return a:diff.' -'
   else
-    execute 'Gedit '.s:fnameescape('/'.filename)
+    call s:Edit('edit',0,s:fnameescape('/'.filename))
     return a:diff
   endif
 endfunction
@@ -757,7 +757,7 @@ function! s:StageDiffEdit() abort
   let [filename, section] = s:stage_info(line('.'))
   let arg = (filename ==# '' ? '.' : filename)
   if section ==# 'staged'
-    return 'Git! diff --cached '.s:shellesc(arg)
+    return s:Git('!0','diff --cached '.s:shellesc(arg))
   elseif section ==# 'untracked'
     let repo = s:repo()
     call repo.git_chomp_in_tree('add','--intent-to-add',arg)
@@ -772,7 +772,7 @@ function! s:StageDiffEdit() abort
     endif
     return ''
   else
-    return 'Git! diff '.s:shellesc(arg)
+    return s:Git('!0','diff '.s:shellesc(arg))
   endif
 endfunction
 
@@ -867,10 +867,10 @@ function! s:StagePatch(lnum1,lnum2) abort
   endfor
   try
     if !empty(add)
-      execute "Git add --patch -- ".join(map(add,'s:shellesc(v:val)'))
+      call s:Git('0','add --patch -- '.join(map(add,'s:shellesc(v:val)')))
     endif
     if !empty(reset)
-      execute "Git reset --patch -- ".join(map(add,'s:shellesc(v:val)'))
+      call s:Git('0','reset --patch -- '.join(map(add,'s:shellesc(v:val,1)')))
     endif
     if exists('first_filename')
       silent! edit!
@@ -1201,7 +1201,7 @@ function! s:Write(force,...) abort
     elseif a:force
       return 'bdelete'
     else
-      return 'Gedit '.fnameescape(filename)
+      return s:Edit('edit',0,fnameescape(filename))
     endif
   endif
   let mytab = tabpagenr()


### PR DESCRIPTION
- Filename arguments to Gedit should not be escaped, as s:Edit already
  s:fnameescape()s when passing filenames to the next command.
  
  Fixes:
  
    A filename with a Vim metacharacter in the Gstatus window cannot be
    diffed via StageDiff because it becomes double escaped:
  
  ```
    #   modified:   etc/%mutt/muttrc
  ```
  
    Pressing 'D' on this line opens two new buffers:
  
  ```
    t/muttrc            (filename shifted by length of repo().dir())
    etc/\%mutt/muttrc   (one actual backslash)
  ```
- s:shellesc should pass an optional {special} argument to
  shellescape() when it is used to sanitize filenames for Vim functions
  and not direct system calls. Vim commands will do one more pass over
  the filename and erroneously expand metacharacters like '%'
  
  Fixes:
  
  ```
    #   modified:   etc/%mutt/muttrc
  
    This same file cannot be processed correctly by s:StagePatch or
    s:StageDiffEdit. Pressing 'p' on this line results in "No
    changes." from git, and pressing 'dp' results in:
  
    fatal: ambiguous argument 'etc/README.markdownmutt/muttrc' ...
  
    Where README.markdown is the current active buffer, replacing
    the '%' in the filename.
  ```

---

In addition to these bugs (now fixed), Fugitive still can't handle
filenames that show up as quoted in git status:

```
a"b.txt  a\b.txt  a❤b.txt
```

git status shows these files as:

```
#   "a\"b.txt"
#   "a\\b.txt"
#   "a\342\235\244b.txt"
```

and fugitive breaks because it doesn't strip the surrounding quotes.
I don't have time to fix this today, but I'll come back to it if it
annoys me in the future.
