### PR TITLE
Add :GBrowser support for Gitlab Site

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -200,10 +200,20 @@ that are part of Git repositories).
                         "git instaweb" from a terminal).  If a range is given,
                         it is appropriately appended to the URL as an anchor.
 
-                        To use with GitHub FI, point g:fugitive_github_domains
+                        It also supports GitHub FI and Gitlab Site.
+
+                        To use them with fugitive, point g:fugitive_github_domains
                         at a list of domains:
 >
-                        let g:fugitive_github_domains = ['https://example.com']
+                        let g:fugitive_github_domains = ['https://git.example.com']
+<
+                        To use with Gitlab Site, enable the
+                        g:fugitive_gitlab_engine switch:
+
+>
+                        let g:fugitive_gitlab_engine = '1'
+<
+                        
 ~
 :[range]Gbrowse!        Like :Gbrowse, but put the URL on the clipboard rather
                         than opening it.

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1911,7 +1911,8 @@ function! s:github_url(repo,url,rev,commit,path,type,line1,line2) abort
   if a:type == 'tree'
     let url = s:sub(root . '/tree/' . commit . '/' . path,'/$','')
   elseif a:type == 'blob'
-    let url = root . '/blob/' . commit . '/' . path
+    let blob_url = exists('g:fugitive_gitlab_engine') ? '/tree/': '/blob/'
+    let url = root . blob_url . commit . '/' . path
     if a:line2 > 0 && a:line1 == a:line2
       let url .= '#L' . a:line1
     elseif a:line2 > 0


### PR DESCRIPTION
I am not familiar with vim script and vim doc, so if there is anything not fit in the style, let me know and I will fix it.

## Why?
gitlab use `/tree/` instead of `/blob/` in the url to view code in the browser.

## Solutions
added a global switches for that
it works together with the `g:fugitive_github_domains` to support gitlab sites

## Examples
With the following setup:

    let g:fugitive_github_domains = ['http://git.zenhacks.org']
    let g:fugitive_gitlab_engine = '1'

I could use `:GBrowser` seamlessly with gitlab.

![Screen Shot 2012-12-09 at 8.14.54 PM.png](https://f.cloud.github.com/assets/1043403/2353/0c8e73bc-41fb-11e2-82cc-4ec80725490c.png)
