### PR TITLE
Escaping Windows shell parameters

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -30,7 +30,7 @@ function! s:shellesc(arg) abort
   if a:arg =~ '^[A-Za-z0-9_/.-]\+$'
     return a:arg
   elseif &shell =~# 'cmd'
-    return '"'.s:gsub(s:gsub(a:arg, '"', '""'), '\%', '"%"').'"'
+    return '"'.s:gsub(s:gsub(a:arg, '"', '\"'), '\%', '%').'"'
   else
     return shellescape(a:arg)
   endif


### PR DESCRIPTION
Hello Tim, 

While testing the Extradite plugin (https://github.com/int3/vim-extradite) I found that the way shell parameters are being escaped is avoiding it to run properly (seems there are other fixes required but this makes Extradite usable).

My initial, but limited, testing shows no side effect on the change, but feel free to suggest me what might be broken (or the proper way you see to fix it... if actually broken).
