### PR TITLE
Issue #301:  use forward slash for temp_files

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1105,7 +1105,7 @@ function! s:Edit(cmd,bang,...) abort
       return 'redraw|echo '.string(':!'.git.' '.args)
     else
       let temp = resolve(tempname())
-      let s:temp_files[temp] = buffer.repo().dir()
+      let s:temp_files[substitute(temp,"\\", "/","g")] = buffer.repo().dir()
       silent execute a:cmd.' '.temp
       if a:cmd =~# 'pedit'
         wincmd P
@@ -1613,7 +1613,7 @@ function! s:Blame(bang,line1,line2,count,args) abort
         setlocal scrollbind nowrap nofoldenable
         let top = line('w0') + &scrolloff
         let current = line('.')
-        let s:temp_files[temp] = s:repo().dir()
+        let s:temp_files[substitute(temp,"\\", "/","g")] = s:repo().dir()
         exe 'keepalt leftabove vsplit '.temp
         let b:fugitive_blamed_bufnr = bufnr
         let w:fugitive_leave = restore


### PR DESCRIPTION
This is what I've been running for quite a while to avoid issue #301: Git! commands broken in windows.  

It's absurdly hackish and there's probably a better solution, but it's been running without problems for quite a while on all my *nix and windows boxes.    Apparently, &lt;amatch&gt;:p always uses forward slashes on windows, I haven't looked at the vim source to figure out why or if there's an exception to that, but using forward slashes for all the entries in temp_files is a quick fix to the problem. 
