### PR TITLE
Add foldlevel to fugitive_diff_restore

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1356,6 +1356,7 @@ function! s:diffthis()
     let w:fugitive_diff_restore .= &l:wrap ? ' wrap' : ' nowrap'
     let w:fugitive_diff_restore .= ' foldmethod=' . &l:foldmethod
     let w:fugitive_diff_restore .= ' foldcolumn=' . &l:foldcolumn
+    let w:fugitive_diff_restore .= ' foldlevel=' . &l:foldlevel
     if has('cursorbind')
       let w:fugitive_diff_restore .= (&l:cursorbind ? ' ' : ' no') . 'cursorbind'
     endif


### PR DESCRIPTION
Hi!

I normally have foldlevelstart to 4, and I rarely have stuff folded for long. After Gdiff, which I do extremely often, the level is lowered, but not restored when the diff is finished.

I've just added foldlevel to fugitive_diff_restore (clever idea, BTW), and I've been testing it for a couple of days, opening and closing diff mode in different ways several times.

I'm a bit hesitant to send this pull request, though, since even if the change is trivial, I don't understand how this is something that seems is only been affecting me. It might be that I have such a different setup that doesn't bother others? Is not a huge deal, of course, but it made me do a "zR" after each diff. And I diff all the files one by one after each commit. :-)

Cheers, and thanks a lot for fugitive.
