### PR TITLE
Add :Gtdiff, :Gtsdiff, :Gtvdiff, and related mappings

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -49,6 +49,9 @@ that are part of Git repositories).
                         dp    |:Git!| diff (p for patch; use :Gw to apply)
                         dp    |:Git| add --intent-to-add (untracked files)
                         dv    |:Gvdiff|
+                        dt    |:Gtdiff|
+                        dts    |:Gtsdiff|
+                        dtv    |:Gtvdiff|
                         O     |:Gtabedit|
                         o     |:Gsplit|
                         p     |:Git| add --patch
@@ -156,6 +159,15 @@ that are part of Git repositories).
 
                                                 *fugitive-:Gvdiff*
 :Gvdiff [revision]      Identical to |:Gdiff|.  For symmetry with |:Gsdiff|.
+
+                                                *fugitive-:Gtdiff*
+:Gtdiff [revision]      Like |:Gdiff|, but open a new tab.
+
+                                                *fugitive-:Gtsdiff*
+:Gtsdiff [revision]     Like |:Gtdiff|, but split horizontally.
+
+                                                *fugitive-:Gtvdiff*
+:Gtvdiff [revision]     Identical to |:Gtdiff|. For symmetry with |:Gtsdiff|.
 
                                                 *fugitive-:Gmove*
 :Gmove {destination}    Wrapper around git-mv that renames the buffer

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1358,6 +1358,9 @@ endfunction
 call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gdiff :execute s:Diff(<bang>0,<f-args>)")
 call s:command("-bar -nargs=* -complete=customlist,s:EditComplete Gvdiff :execute s:Diff(0,<f-args>)")
 call s:command("-bar -nargs=* -complete=customlist,s:EditComplete Gsdiff :execute s:Diff(1,<f-args>)")
+call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gtdiff :tab sp | execute s:Diff(<bang>0,<f-args>)")
+call s:command("-bar -nargs=* -complete=customlist,s:EditComplete Gtvdiff :tab sp | execute s:Diff(0,<f-args>)")
+call s:command("-bar -nargs=* -complete=customlist,s:EditComplete Gtsdiff :tab sp | execute s:Diff(1,<f-args>)")
 
 augroup fugitive_diff
   autocmd!
@@ -2083,6 +2086,9 @@ function! s:BufReadIndex()
     nnoremap <buffer> <silent> dd :<C-U>execute <SID>StageDiff('Gvdiff')<CR>
     nnoremap <buffer> <silent> dh :<C-U>execute <SID>StageDiff('Gsdiff')<CR>
     nnoremap <buffer> <silent> ds :<C-U>execute <SID>StageDiff('Gsdiff')<CR>
+    nnoremap <buffer> <silent> dt :<C-U>execute <SID>StageDiff('Gtdiff')<CR>
+    nnoremap <buffer> <silent> dts :<C-U>execute <SID>StageDiff('Gtsdiff')<CR>
+    nnoremap <buffer> <silent> dtv :<C-U>execute <SID>StageDiff('Gtvdiff')<CR>
     nnoremap <buffer> <silent> dp :<C-U>execute <SID>StageDiffEdit()<CR>
     nnoremap <buffer> <silent> dv :<C-U>execute <SID>StageDiff('Gvdiff')<CR>
     nnoremap <buffer> <silent> p :<C-U>execute <SID>StagePatch(line('.'),line('.')+v:count1-1)<CR>


### PR DESCRIPTION
Upon further reflection,  I concluded that diffs in a new split are a little too silly. Diffs in a new tab, though, still seem like a good idea, so I added it. This closes issue #318
- `:Gtdiff` is `:Gdiff` but in a new tab
- `:Gtsdiff` is `:Gsdiff` but in a new tab
- `:Gtvdiff` is identical to `:Gtdiff` (for symmetry with `:Gtsdiff`)
- `dt` in the status window does `:Gtdiff`
- `dts` in the status window does `:Gtsdiff`
- `dtv` in the status window does `:Gtvdiff`
