### PR TITLE
Change if block to correct ending

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -243,7 +243,7 @@ function! s:repo_bare() dict abort
     return 0
   else
     return self.configured_tree() ==# ''
-  endtry
+  endif
 endfunction
 
 function! s:repo_translate(spec) dict abort


### PR DESCRIPTION
I've found a mismatched `endtry` thanks to https://github.com/dbakker/vim-lint
