### PR TITLE
Compatibility with git 1.8.5

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -9,7 +9,7 @@ endif
 let g:loaded_fugitive = 1
 
 if !exists('g:fugitive_git_executable')
-  let g:fugitive_git_executable = 'git'
+  let g:fugitive_git_executable = 'git -c status.displaycommentprefix=true'
 endif
 
 " Utility {{{1


### PR DESCRIPTION
git 1.8.5 removes the git-status '#' prefix output, something required
by fugitive :Gstatus command.
