### PR TITLE
Add option to stop fugitive from changing the tags setting.

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -161,12 +161,14 @@ function! fugitive#detect(path)
     if expand('%:p') =~# '//'
       call buffer.setvar('&path', s:sub(buffer.getvar('&path'), '^\.%(,|$)', ''))
     endif
-    if stridx(buffer.getvar('&tags'), escape(b:git_dir.'/tags', ', ')) == -1
-      call buffer.setvar('&tags', escape(b:git_dir.'/tags', ', ').','.buffer.getvar('&tags'))
-      if &filetype !=# ''
-        call buffer.setvar('&tags', escape(b:git_dir.'/'.&filetype.'.tags', ', ').','.buffer.getvar('&tags'))
-      endif
-    endif
+    if !exists("g:fugitive_git_tags") || g:fugitive_git_tags
+     if stridx(buffer.getvar('&tags'), escape(b:git_dir.'/tags', ', ')) == -1
+       call buffer.setvar('&tags', escape(b:git_dir.'/tags', ', ').','.buffer.getvar('&tags'))
+       if &filetype !=# ''
+         call buffer.setvar('&tags', escape(b:git_dir.'/'.&filetype.'.tags', ', ').','.buffer.getvar('&tags'))
+       endif
+     endif
+   endif
   endif
 endfunction
 


### PR DESCRIPTION
Fugitive would automatically insert $repo/.git/tags and
$repo/.git/filetype.tags to the tags setting. This behavior is undocumented and may sometimes
be unwanted so i added the g:fugitive_git_tags variable to allow toggling it
on/off.
