### PR TITLE
add 'diff in new tab'

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -787,7 +787,9 @@ function! s:StageDiff(diff) abort
 endfunction
 
 function! s:StageDiffTab(diff) abort
-  execute 'tabedit %'
+  let curfile = expand('%:p')
+  execute 'tabnew'
+  execute 'edit' curfile
   return s:StageDiff(a:diff)
 endfunction
 

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -786,6 +786,11 @@ function! s:StageDiff(diff) abort
   endif
 endfunction
 
+function! s:StageDiffTab(diff) abort
+  execute 'tabedit %'
+  return s:StageDiff(a:diff)
+endfunction
+
 function! s:StageDiffEdit() abort
   let [filename, section] = s:stage_info(line('.'))
   let arg = (filename ==# '' ? '.' : filename)
@@ -1370,6 +1375,7 @@ endfunction
 call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gdiff :execute s:Diff(<bang>0,<f-args>)")
 call s:command("-bar -nargs=* -complete=customlist,s:EditComplete Gvdiff :execute s:Diff(0,<f-args>)")
 call s:command("-bar -nargs=* -complete=customlist,s:EditComplete Gsdiff :execute s:Diff(1,<f-args>)")
+call s:command("-bar -nargs=* -complete=customlist,s:EditComplete Gtdiff :tabnew %|execute s:Diff(0,<f-args>)")
 
 augroup fugitive_diff
   autocmd!
@@ -2110,6 +2116,7 @@ function! s:BufReadIndex()
     nnoremap <buffer> <silent> ds :<C-U>execute <SID>StageDiff('Gsdiff')<CR>
     nnoremap <buffer> <silent> dp :<C-U>execute <SID>StageDiffEdit()<CR>
     nnoremap <buffer> <silent> dv :<C-U>execute <SID>StageDiff('Gvdiff')<CR>
+    nnoremap <buffer> <silent> dt :<C-U>execute <SID>StageDiffTab('Gvdiff')<CR>
     nnoremap <buffer> <silent> p :<C-U>execute <SID>StagePatch(line('.'),line('.')+v:count1-1)<CR>
     xnoremap <buffer> <silent> p :<C-U>execute <SID>StagePatch(line("'<"),line("'>"))<CR>
     nnoremap <buffer> <silent> q :<C-U>if bufnr('$') == 1<Bar>quit<Bar>else<Bar>bdelete<Bar>endif<CR>

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -787,9 +787,7 @@ function! s:StageDiff(diff) abort
 endfunction
 
 function! s:StageDiffTab(diff) abort
-  let curfile = expand('%:p')
-  execute 'tabnew'
-  execute 'edit' curfile
+  execute 'tab split'
   return s:StageDiff(a:diff)
 endfunction
 


### PR DESCRIPTION
I've already searched and read postings related with "diff in tab page" topic ([Issue #36](https://github.com/tpope/vim-fugitive/issues/36), [Issue #76](https://github.com/tpope/vim-fugitive/issues/76), [Pull Request #319](https://github.com/tpope/vim-fugitive/pull/319)).

I don't think that you prefer doing diff in a tab page.
But I think not a few people want to do diff in that way, because diff in a tab page has several advantages :
- Maximized diff window would be helpful for comparing two files, especially for long files. Even for short files, one can compare two files at a first glance.
- Diff in that way does not have any influence on the original working buffers / windows in vim. After diff, one can return to their original workspace just by closing the diff tab page.

I added only two features, so I think that the commands are not getting messy and still clear.
- 'dt' in Gstatus window
- :Gtdiff command

This is my first pull request, so please understand me if I make some mistakes.