### PR TITLE
Fix slowness when searching for networked git repos under Cygwin.

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -130,6 +130,12 @@ function! fugitive#extract_git_dir(path) abort
   let root = s:shellslash(simplify(fnamemodify(a:path, ':p:s?[\/]$??')))
   let previous = ""
   while root !=# previous
+    if root =~# '\v^//%([^/]+/?)?$'
+      " This is for accessing network shares from Cygwin Vim. There won't be
+      " any git directory called //.git or //serverName/.git so let's avoid
+      " checking for them since such checks are extremely slow.
+      break
+    endif
     let dir = s:sub(root, '[\/]$', '') . '/.git'
     let type = getftype(dir)
     if type ==# 'dir' && fugitive#is_git_dir(dir)


### PR DESCRIPTION
The algorithm in fugitive#extract_git_dir() is to move upwards in the
file system hierarchy until a sub-directory called .git is found. When
accessing a file on a network share from a Cygwin Vim and the file is not
within a git repo, this eventually causes a check for the existence of
//serverName/.git and //.git. Such checks are extremely slow so let's
avoid them.
