### PR TITLE
Respect GIT_CEILING_DIRECTORIES, see git(1).

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -136,6 +136,9 @@ function! fugitive#extract_git_dir(path) abort
       " checking for them since such checks are extremely slow.
       break
     endif
+    if index(split($GIT_CEILING_DIRECTORIES, ':'), root) >= 0
+      break
+    endif
     let dir = s:sub(root, '[\/]$', '') . '/.git'
     let type = getftype(dir)
     if type ==# 'dir' && fugitive#is_git_dir(dir)


### PR DESCRIPTION
From git(1):

```
GIT_CEILING_DIRECTORIES
       This should be a colon-separated list of absolute paths. If set, it is a list of directories that Git
       should not chdir up into while looking for a repository directory (useful for excluding slow-loading
       network directories). It will not exclude the current working directory or a GIT_DIR set on the command
       line or in the environment. Normally, Git has to read the entries in this list and resolve any symlink
       that might be present in order to compare them with the current directory. However, if even this access
       is slow, you can add an empty entry to the list to tell Git that the subsequent entries are not symlinks
       and needn’t be resolved; e.g., GIT_CEILING_DIRECTORIES=/maybe/symlink::/very/slow/non/symlink.
```

This patch currently does not duplicate git's behavior of resolving symlinks.
