### PR TITLE
Show correct diffs for conflicts while rebasing

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -736,12 +736,12 @@ function! s:stage_info(lnum) abort
   endwhile
   if !lnum
     return ['', '']
-  elseif getline(lnum+1) =~# '^# .*\<git \%(reset\|rm --cached\) ' || getline(lnum) ==# '# Changes to be committed:'
-    return [matchstr(filename, colon.' *\zs.*'), 'staged']
   elseif getline(lnum+2) =~# '^# .*\<git checkout ' || getline(lnum) ==# '# Changes not staged for commit:'
     return [matchstr(filename, colon.' *\zs.*'), 'unstaged']
   elseif getline(lnum+1) =~# '^# .*\<git add/rm ' || getline(lnum) ==# '# Unmerged paths:'
     return [matchstr(filename, colon.' *\zs.*'), 'unmerged']
+  elseif getline(lnum+1) =~# '^# .*\<git \%(reset\|rm --cached\) ' || getline(lnum) ==# '# Changes to be committed:'
+    return [matchstr(filename, colon.' *\zs.*'), 'staged']
   else
     return [filename, 'untracked']
   endif


### PR DESCRIPTION
This patch addresses issue reported in #407 by @qstrahl. Recent versions
of git have changed the way statuses are displayed for unmerged files
while rebasing. The result is that unmerged files in a rebase conflict
are treated like staged files. This patch corrects this issue by
re-ordering the checks that are performed to determine which status
section the file is located in so that the check for the unmerged file
happens before the check for the staged file.
