### PR TITLE
Look for $GIT_DIR and $GIT_WORK_TREE

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -139,6 +139,9 @@ function! fugitive#extract_git_dir(path) abort
     if index(split($GIT_CEILING_DIRECTORIES, ':'), root) >= 0
       break
     endif
+    if root ==# $GIT_WORK_TREE && fugitive#is_git_dir($GIT_DIR)
+      return $GIT_DIR
+    endif
     let dir = s:sub(root, '[\/]$', '') . '/.git'
     let type = getftype(dir)
     if type ==# 'dir' && fugitive#is_git_dir(dir)


### PR DESCRIPTION
There are rare situations where a user has manually specified what they
wish to use as their work-tree directory, and even rarer situations
where the user wishes the Git directory to be customized. In the case
the user has set these using environment variables, vim-fugitive takes
advantage of these settings in order to set up.

Note that git-config(1) allows setting the work-tree and Git dir in
a number of ways (see the core.worktree) setting. This change only
respects the environment variable method, not the config file method.
