### PR TITLE
Add :Glsfiles, :Gllsfiles commands

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -88,6 +88,16 @@ that are part of Git repositories).
 :Gllog [args]           Like |:Glog|, but use the location list instead of the
                         quickfix list.
 
+                                                *fugitive-:Glsfiles*
+:Glsfiles [args]        Load the output of git-ls-files in the quickfix list.
+                        This does not currently work if the output lists
+                        something besides just the path, as is the case with
+                        -s.
+
+                                                *fugitive-:Gllsfiles*
+:Gllsfiles [args]       Like |:Glsfiles|, but use the location list instead of the
+                        quickfix list.
+
                                         *fugitive-:Gedit* *fugitive-:Ge*
 :Gedit [revision]       |:edit| a |fugitive-revision|.
 

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1056,6 +1056,8 @@ call s:command("-bang -nargs=? -complete=customlist,s:EditComplete Ggrep :execut
 call s:command("-bang -nargs=? -complete=customlist,s:EditComplete Glgrep :execute s:Grep('lgrep',<bang>0,<q-args>)")
 call s:command("-bar -bang -nargs=* -complete=customlist,s:EditComplete Glog :execute s:Log('grep<bang>',<f-args>)")
 call s:command("-bar -bang -nargs=* -complete=customlist,s:EditComplete Gllog :execute s:Log('lgrep<bang>',<f-args>)")
+call s:command("-bar -bang -nargs=* -complete=customlist,s:EditComplete Glsfiles :execute s:LsFiles('grep<bang>',<f-args>)")
+call s:command("-bar -bang -nargs=* -complete=customlist,s:EditComplete Gllsfiles :execute s:LsFiles('lgrep<bang>',<f-args>)")
 
 function! s:Grep(cmd,bang,arg) abort
   let grepprg = &grepprg
@@ -1128,6 +1130,24 @@ function! s:Log(cmd,...) abort
   endtry
 endfunction
 
+function! s:LsFiles(cmd,...) abort
+  let cmd = ['--no-pager', 'ls-files']
+  let cmd += map(copy(a:000),'s:sub(v:val,"^\\%(%(:\\w)*)","\\=fnamemodify(s:buffer().path(),submatch(1))")')
+  let grepformat = &grepformat
+  let grepprg = &grepprg
+  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+  let dir = getcwd()
+  try
+    execute cd.'`=s:repo().tree()`'
+    let &grepprg = escape(call(s:repo().git_command,cmd,s:repo()),'%#')
+    let &grepformat = '%f'
+    exe a:cmd
+  finally
+    let &grepformat = grepformat
+    let &grepprg = grepprg
+    execute cd.'`=dir`'
+  endtry
+endfunction
 " }}}1
 " Gedit, Gpedit, Gsplit, Gvsplit, Gtabedit, Gread {{{1
 


### PR DESCRIPTION
These put the output of git-ls-files in the error/location list.

Note that they currently assume that the output is just the file names,
so running `:Glsfiles -s` will not work properly.

Feel free to kill this if you do not think it is a useful enough feature or to tell me to make a bunch of changes to it; you're not going to hurt my feelings. I also don't mind if you take a while to get back to me, especially since I think we agree that this is a fairly low-priority issue. 

refs #132
