### PR TITLE
Set the local, not global, value of cursorbind

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1514,7 +1514,7 @@ function! s:Diff(bang,...) abort
     let commit = matchstr(spec,'\C[^:/]//\zs\x\+')
     let restore = s:diff_restore()
     if exists('+cursorbind')
-      set cursorbind
+      setlocal cursorbind
     endif
     let w:fugitive_diff_restore = restore
     if s:buffer().compare_age(commit) < 0


### PR DESCRIPTION
From src/option.c:

``` c
/*
 * Options local to a window have a value local to a buffer and global to all
 * buffers.  Indicate this by setting "var" to VAR_WIN.
 */
#define VAR_WIN ((char_u *)-1)
…
    {"cursorbind",  "crb",  P_BOOL|P_VI_DEF,
                            (char_u *)VAR_WIN, PV_CRBIND,
                                      ^^^^^^^
```

Steps to reproduce:
1. `:Gstatus` with at least one modified file
2. `D` on that file to open two diff windows
3. `:only` from one of the windows
4. `:Gstatus` again
5. `D` to diff again
6. Move the cursor in one of the diff windows and watch the `Gstatus` window scroll with the cursor
