### PR TITLE
`q` should not wait in status window.

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -689,7 +689,7 @@ function! s:Status() abort
     Gpedit :
     wincmd P
     setlocal foldmethod=syntax foldlevel=1
-    nnoremap <buffer> <silent> q    :<C-U>bdelete<CR>
+    nnoremap <buffer> <silent> <nowait> q    :<C-U>bdelete<CR>
   catch /^fugitive:/
     return 'echoerr v:errmsg'
   endtry


### PR DESCRIPTION
In the status window, `q` doesn't wait for the built-in `q:`, `q/`, etc., so it's fair to also ignore custom q-prefixed maps. 
