### PR TITLE
Override status.short configuration

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2115,6 +2115,7 @@ function! s:BufReadIndex() abort
         let cmd = s:repo().git_command(
               \ '-c', 'status.displayCommentPrefix=true',
               \ '-c', 'color.status=false',
+              \ '-c', 'status.short=false',
               \ 'status')
       endif
       try


### PR DESCRIPTION
Git allows the "status.short" configuration to implicitly pass `--short` to
git-status. Override that value so that we see "long" status format.
