### PR TITLE
Restore 'foldenable' setting when diff ends

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1422,6 +1422,7 @@ function! s:diff_restore() abort
         \ . ' foldmethod=' . &l:foldmethod
         \ . ' foldcolumn=' . &l:foldcolumn
         \ . ' foldlevel=' . &l:foldlevel
+        \ . (&l:foldenable ? ' foldenable' : ' nofoldenable')
   if has('cursorbind')
     let restore .= (&l:cursorbind ? ' ' : ' no') . 'cursorbind'
   endif


### PR DESCRIPTION
After finishing a diff session, the foldenable settings should be
restored to it's previous value.
