### PR TITLE
Improve hack to set/restore the cursor with Gdiff

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1527,6 +1527,11 @@ function! s:Diff(bang,...) abort
       setlocal cursorbind
     endif
     let w:fugitive_diff_restore = restore
+    if exists('*winsaveview')  " vim 7.0214
+      let curview = winsaveview()
+    else
+      let curpos = getpos('.')
+    endif
     if s:buffer().compare_age(commit) < 0
       execute 'rightbelow '.vert.'diffsplit '.s:fnameescape(spec)
     else
@@ -1536,6 +1541,11 @@ function! s:Diff(bang,...) abort
     let winnr = winnr()
     if getwinvar('#', '&diff')
       wincmd p
+      if exists('curview')
+        call winrestview(curview)
+      else
+        call setpos('.', curpos)
+      endif
       call feedkeys("\<C-W>p", 'n')
     endif
     return ''


### PR DESCRIPTION
This uses `winsaveview` or `getpos` on the original buffer before
`diffsplit` and restores it before changing to the diff window.

This makes restoring the original position more reliable.

Fixes #428
Ref: #429
