### PR TITLE
Add the :Gtag command for tag creation

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -70,6 +70,13 @@ that are part of Git repositories).
                         git-add and git-reset while a commit message is
                         pending.
 
+                                                *fugitive-:Gtag*
+:Gtag [args]            A wrapper around git-tag.  Unless the arguments given
+                        would skip the invocation of an editor (e.g., -m), a
+                        split window will be used to obtain a commit message.
+                        Write and close that window (:wq or |:Gwrite|) to
+                        finish the commit.
+
                                                 *fugitive-:Ggrep*
 :Ggrep [args]           |:grep| with git-grep as 'grepprg'.
 


### PR DESCRIPTION
:Gtag is for tag creation only - tag listing and tag deletion is
blocked. Since these commands don't require a message, they should be
used with :Git.

The tag message buffer uses the gitcommit filetype since any ftplugin
that helps in writing commit messages and targets the gitcommit buffer
will probably be useful for writing tag messages as well.
