### PR TITLE
Open :Gcommit in a tab based on global variable

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -70,6 +70,12 @@ that are part of Git repositories).
                         git-add and git-reset while a commit message is
                         pending.
 
+                        To open the commit message in a separate tab, useful
+                        with :Gcommit -v:
+>
+                        let g:fugitive_commit_tab = 1
+~
+
                                                 *fugitive-:Gmerge*
 :Gmerge [args]          Calls git-merge and loads errors and conflicted files
                         into the quickfix list.  Opens a |:Gcommit| style

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1016,7 +1016,11 @@ function! s:Commit(args) abort
           execute (search('^#','n')+1).'wincmd+'
           setlocal nopreviewwindow
         else
-          execute 'keepalt split '.s:fnameescape(msgfile)
+          if exists('g:fugitive_commit_tab')
+            execute 'keepalt tabedit '.s:fnameescape(msgfile)
+          else
+            execute 'keepalt split '.s:fnameescape(msgfile)
+          endif
         endif
         let b:fugitive_commit_arguments = args
         setlocal bufhidden=wipe filetype=gitcommit


### PR DESCRIPTION
I always use git commit -v to do a final check over my commits. It would be cool to have this open in a new tab for better visibility. Let me know if anything else needs doing with this.
