### PR TITLE
Add tags from the root of the git working tree

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -192,6 +192,7 @@ function! fugitive#detect(path) abort
       if &filetype !=# '' && filereadable(b:git_dir.'/'.&filetype.'.tags')
         call buffer.setvar('&tags', escape(b:git_dir.'/'.&filetype.'.tags', ', ').','.buffer.getvar('&tags'))
       endif
+      call buffer.setvar('&tags', simplify(escape(b:git_dir.'/../tags', ', ')).','.buffer.getvar('&tags'))
     endif
     silent doautocmd User Fugitive
   endif


### PR DESCRIPTION
This is useful for projects like Linux where the location of the tags file is
always in the root of the working tree and moving it is non-trivial.
