### PR TITLE
fix :diffoff!

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1723,14 +1723,16 @@ function! s:Diff(vert,...) abort
     let spec = s:repo().translate(file)
     let commit = matchstr(spec,'\C[^:/]//\zs\x\+')
     let restore = s:diff_restore()
-    if exists('+cursorbind')
-      setlocal cursorbind
-    endif
     let w:fugitive_diff_restore = restore
     if s:buffer().compare_age(commit) < 0
       execute 'rightbelow '.vert.'diffsplit '.s:fnameescape(spec)
     else
       execute 'leftabove '.vert.'diffsplit '.s:fnameescape(spec)
+    endif
+    if exists('+cursorbind')
+      wincmd p
+      setlocal cursorbind
+      wincmd p
     endif
     let w:fugitive_diff_restore = restore
     let winnr = winnr()


### PR DESCRIPTION
`:diffsplit` records settings (like `cursorbind`, `scrollbind`, ...), and
`:diffoff` resotres them.  So if you want to set up `cursorbind` it is
better after executing `:diffsplit`.
