### PR TITLE
Use resolved path to extract git dir

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -172,7 +172,7 @@ function! fugitive#detect(path) abort
     unlet b:git_dir
   endif
   if !exists('b:git_dir')
-    let dir = fugitive#extract_git_dir(a:path)
+    let dir = fugitive#extract_git_dir(resolve(a:path))
     if dir !=# ''
       let b:git_dir = dir
     endif


### PR DESCRIPTION
Hi,

all my dotfiles are put under `~/.dotfiles` and mangaged by a shell script, that only creates the approriate symlinks in`~`, if the corresponding executables are found.

Now, if you open `~/.zshenv` (which is really a symlink to `~/.dotfiles/zsh/zshenv`), fugitive wouldn't find a git dir -> wouldn't set `b:git_dir` -> `fugitive#head()` wouldn't be executed -> my statusline wouldn't look as fancy.

Thanks for fugitive.
