### PR TITLE
Expand `%` instead of `<amatch>` in the Buf* autocommands

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -218,7 +218,7 @@ endfunction
 
 augroup fugitive
   autocmd!
-  autocmd BufNewFile,BufReadPost * call fugitive#detect(expand('<amatch>:p'))
+  autocmd BufNewFile,BufReadPost * call fugitive#detect(expand('%:p'))
   autocmd FileType           netrw call fugitive#detect(expand('%:p'))
   autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTreeRoot.path.str())
   autocmd VimEnter * if expand('<amatch>')==''|call fugitive#detect(getcwd())|endif


### PR DESCRIPTION
This is relevant in case a previous BufReadPost autocmd changes the file
name using `:file` - fugitive should use the new/current name then.