### PR TITLE
(Re)store the current window in `s:diffoff_all`

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1667,6 +1667,7 @@ function! s:diffoff() abort
 endfunction
 
 function! s:diffoff_all(dir) abort
+  let curwin = winnr()
   for nr in range(1,winnr('$'))
     if getwinvar(nr,'&diff')
       if nr != winnr()
@@ -1678,6 +1679,7 @@ function! s:diffoff_all(dir) abort
       endif
     endif
   endfor
+  execute curwin.'wincmd w'
 endfunction
 
 function! s:buffer_compare_age(commit) dict abort


### PR DESCRIPTION
This is required to make Vim execute the "Enter" autocommands when
closing the fugitive window.

Fixes: https://github.com/tpope/vim-fugitive/issues/421