### PR TITLE
use same escaping for cmd and powershell

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -27,7 +27,7 @@ function! s:gsub(str,pat,rep) abort
 endfunction
 
 function! s:winshell() abort
-  return &shell =~? 'cmd' || exists('+shellslash') && !&shellslash
+  return &shell =~? '\v(cmd|powershell)' || exists('+shellslash') && !&shellslash
 endfunction
 
 function! s:shellesc(arg) abort


### PR DESCRIPTION
Powershell, just like cmd, uses doubled double quotation marks 
to escape double quotation marks. Therefore s:shellesc() should 
take account of cmd and powershell as well.

This was discussed at https://github.com/tpope/vim-fugitive/issues/435
