### PR TITLE
s:Diff: use winnr with `<C-W>w` instead of `<C-W>p`

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1759,7 +1759,7 @@ function! s:Diff(vert,...) abort
     let winnr = winnr()
     if getwinvar('#', '&diff')
       wincmd p
-      call feedkeys("\<C-W>p", 'n')
+      call feedkeys(winnr."\<C-W>w", 'n')
     endif
     return ''
   catch /^fugitive:/


### PR DESCRIPTION
This is more reliable and fixes an issue where the syntastic location
list of the original file would be focused after `:Gdiff`.

Ref: https://github.com/blueyed/vim-fugitive/commit/c99f0ff06bd1915b2f05c5750283aa9e826ad3d8#commitcomment-9434351