### PR TITLE
Provide g:fugitive_no_maps to disable key maps

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -193,8 +193,10 @@ function! fugitive#detect(path) abort
         let &mls = save_mls
       endtry
     endif
-    cnoremap <buffer> <expr> <C-R><C-G> fnameescape(<SID>recall())
-    nnoremap <buffer> <silent> y<C-G> :call setreg(v:register, <SID>recall())<CR>
+    if !exists('g:fugitive_no_maps')
+      cnoremap <buffer> <expr> <C-R><C-G> fnameescape(<SID>recall())
+      nnoremap <buffer> <silent> y<C-G> :call setreg(v:register, <SID>recall())<CR>
+    endif
     let buffer = fugitive#buffer()
     if expand('%:p') =~# '//'
       call buffer.setvar('&path', s:sub(buffer.getvar('&path'), '^\.%(,|$)', ''))


### PR DESCRIPTION
Add variable g:fugitive_no_maps. If set, `y<C-G>` and `<C-R><C-G>` are not
mapped.

Resolves tpope/vim-fugitive#394