### PR TITLE
Show all untracked files in :Gstatus window

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2408,13 +2408,16 @@ function! s:BufReadIndex() abort
     else
       let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
       let dir = getcwd()
-      if fugitive#git_version() =~# '^0\|^1\.[1-7]\.'
+      if fugitive#git_version() =~# '^0\|^1\.[1-3]\.'
         let cmd = s:repo().git_command('status')
+      elseif fugitive#git_version() =~# '^1\.[4-7]\.'
+        let cmd = s:repo().git_command('status', '-u')
       else
         let cmd = s:repo().git_command(
               \ '-c', 'status.displayCommentPrefix=true',
               \ '-c', 'color.status=false',
               \ '-c', 'status.short=false',
+              \ '-c', 'status.showUntrackedFiles=all',
               \ 'status')
       endif
       try


### PR DESCRIPTION
Previously, if there were untracked files inside an untracked folder,
:Gstatus would only show the new folder. Attempting to run a diff on the
folder would pass the directory name, which would result in Vim opening
a directory listing. This makes :Gstatus list all untracked files, even
if they're inside untracked folders. This requires Git >=1.4, and will
silently fall back to the old behavior on earlier versions.

Closes #605.