### PR TITLE
Rename ':Make' command in s:Dispatch()

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1573,8 +1573,8 @@ function! s:Dispatch(bang, args)
     let &l:errorformat = s:common_efm
     let &l:makeprg = g:fugitive_git_executable . ' ' . a:args
     execute cd fnameescape(s:repo().tree())
-    if exists(':Make') == 2
-      noautocmd Make
+    if exists(':FugitiveMake') == 2
+      noautocmd FugitiveMake
     else
       silent noautocmd make!
       redraw!


### PR DESCRIPTION
The vim command ':Make' is often used to build software, so the fugitive Make command is named 'FugitiveMake'.

Change-Id: Iaf84df8c854002d6b6c0a5ae8794d2346cf45b13