### PR TITLE
Add AppStream metadata.

### DIFF
--- a/appstream/vim-fugitive.metainfo.xml
+++ b/appstream/vim-fugitive.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+<id>vim-fugitive</id>
+<extends>gvim.desktop</extends>
+<name>fugitive.vim</name>
+<summary>A Git wrapper so awesome, it should be illegal</summary>
+<url type="homepage">http://www.vim.org/scripts/script.php?script_id=2975</url>
+<metadata_license>CC0-1.0</metadata_license>
+<project_license>VIM</project_license>
+<updatecontact>v.ondruch@gmail.com</updatecontact>
+</component>


### PR DESCRIPTION
I am going to package fugitive.vim for Fedora and since I'd like to provide best user experience, i.e. to have this plugin shown in gnome-software [1], it be cool if you can include these metadata in your upstream repository.

[1] https://blogs.gnome.org/hughsie/2014/06/11/application-addons-in-gnome-software/
