### PR TITLE
Make Ggrep to work properly on Mac

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1239,7 +1239,7 @@ function! s:Grep(cmd,bang,arg) abort
   let dir = getcwd()
   try
     execute cd.'`=s:repo().tree()`'
-    let &grepprg = s:repo().git_command('--no-pager', 'grep', '-n')
+    let &grepprg = s:repo().git_command('--no-pager', 'grep', '-n', '--no-color')
     let &grepformat = '%f:%l:%m'
     exe a:cmd.'! '.escape(matchstr(a:arg,'\v\C.{-}%($|[''" ]\@=\|)@='),'|')
     let list = a:cmd =~# '^l' ? getloclist(0) : getqflist()


### PR DESCRIPTION
- Color were causing to appear strange characters in the result.
- These characters made impossible to navigate the results
- The solution was to disable colors while executing git grep