### PR TITLE
Force fugitive to use English.

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -9,7 +9,7 @@ endif
 let g:loaded_fugitive = 1
 
 if !exists('g:fugitive_git_executable')
-  let g:fugitive_git_executable = 'git'
+  let g:fugitive_git_executable = 'LANG=en_US git'
 endif
 
 " Section: Utility


### PR DESCRIPTION
fugitive scrapes output from git, so commands like "-" within a :Gstatus
split fail if git's output is in another language.

Closes #642.