### PR TITLE
diffoff_all: restore '#' window, use winrestcmd

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1681,7 +1681,13 @@ function! s:diffoff() abort
 endfunction
 
 function! s:diffoff_all(dir) abort
-  let curwin = winnr()
+  " By entering a window, its height is potentially increased from 0 to 1
+  " (the minimum for the current window). To avoid any modification, save the
+  " window sizes and restore them after visiting all windows.
+  let winrestcmd = winrestcmd()
+  let currwin = winnr()
+  let prevwin = winnr('#') ? winnr('#') : 1
+
   for nr in range(1,winnr('$'))
     if getwinvar(nr,'&diff')
       if nr != winnr()
@@ -1693,7 +1699,10 @@ function! s:diffoff_all(dir) abort
       endif
     endif
   endfor
-  execute curwin.'wincmd w'
+
+  execute prevwin.'wincmd w'
+  execute currwin.'wincmd w'
+  silent! execute winrestcmd
 endfunction
 
 function! s:buffer_compare_age(commit) dict abort


### PR DESCRIPTION
The code is based on
[`ArgsAndMore#Windo`](https://github.com/vim-scripts/ArgsAndMore/blob/848dec40e4d23fa3124c83009512eb5a22bd36b8/autoload/ArgsAndMore.vim#L127-L138).

This is a followup to e065e4f8.
