### PR TITLE
graphical log navigation

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2963,6 +2963,121 @@ function! fugitive#foldtext() abort
   return foldtext()
 endfunction
 
+function! Glogga()
+  call GlogGraph(1)
+endfunction
+
+function! Glogg()
+  call GlogGraph(0)
+endfunction
+
+function! GlogGraph(showAll)
+  silent! wincmd P
+  if !&previewwindow
+    execute 'bo ' . &previewheight . ' new'
+    set previewwindow
+  endif
+
+  execute "silent %delete_"
+  
+  setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted nowrap
+
+  let all = ""
+  if a:showAll
+    let all = " --all"
+  endif
+  let git_log_command = "git log --decorate --graph --oneline --color=always" . all
+  execute "silent 0read !". git_log_command
+
+  set nowrap
+  if !IsAnsiEscEnabled(bufnr("%"))
+    AnsiEsc
+  endif
+  normal 1G
+  map <buffer> <Enter> :call OpenCommit()<CR>
+endfunction
+
+function! GotoWin(winnr) 
+  let cmd = type(a:winnr) == type(0) ? a:winnr . 'wincmd w'
+                                     \ : 'wincmd ' . a:winnr
+  execute cmd
+endfunction
+
+function! OpenCommit()
+  let line = getline(".")
+  let commit = substitute(line, '.*\*\s\+\e[.\{-}m\(.\{-}\)\e.*', '\1', "g")  
+
+  "Open in another buffer (always same place)
+  let commitwinnr = bufwinnr("__Commit__")
+  if commitwinnr != -1
+    call GotoWin(commitwinnr)
+  else
+    bo new
+    file __Commit__
+  endif
+  execute "silent %delete_"
+  
+  setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted nowrap
+
+  execute "silent 0read !git show" commit
+  set filetype=git
+  set foldmethod=syntax
+
+  map <buffer> <Enter> :call OpenRealFile(0)<CR>
+  map <buffer> <S-Enter> :call OpenRealFile(1)<CR>
+endfunction
+
+function! OpenRealFile(openFrom)
+  let lnum = line(".")
+  let selectedLnum = lnum
+  while lnum > 0
+    let line = getline(lnum)
+    if line =~# '^diff --git \%(a/.*\|/dev/null\) \%(b/.*\|/dev/null\)'
+      let sr = substitute(line, '^diff --git \(a/.*\|/dev/null\) \(b/.*\|/dev/null\)', 
+          \ 'let fromfile = "\1" | let tofile = "\2"', '')
+      if sr != line
+        execute sr
+        if a:openFrom
+          let noprefixfromfile = substitute(fromfile, '^..', '', '')
+          if fromfile == "/dev/null"
+            echom "file created: no from-file"
+          elseif !filereadable(noprefixfromfile)
+            echom "file " . noprefixfromfile . ": not exists"
+          else
+            exe "vsplit " . noprefixfromfile
+            exe  "normal " . fromline . "G"
+          endif
+        else
+          let noprefixtofile = substitute(tofile, '^..', '', '')
+          if tofile == "/dev/null"
+            echom "file deleted: no to-file"
+          elseif !filereadable(noprefixtofile)
+            echom "file " . noprefixtofile . ": not exists"
+          else
+            exe "vsplit " . noprefixtofile
+            exe "normal " . toline . "G"
+          endif
+        endif
+        break
+      endif
+    elseif line =~# '^@@ -\d\+,\d\+ +\d\+,\d\+'
+      let sr = substitute(line, '^@@ -\(\d\+\),\(\d\+\) +\(\d\+\),\(\d\+\).*', 
+                \ 'let fromline = \1 | let fromcol = \2 | let toline = \3 | let tocol = \4', '')
+      if line != sr
+         echo sr
+        exe sr
+        let offsetline = selectedLnum - lnum - 1
+        let fromline += offsetline
+        let toline += offsetline
+      endif
+    endif
+    let lnum -= 1
+  endwhile
+endfunction
+
+command! Glogg :call Glogg()
+command! Glogga :call Glogga()
+
 augroup fugitive_foldtext
   autocmd!
   autocmd User Fugitive


### PR DESCRIPTION
I'm not expert on vim-fugitive internals so I prepare this quick an dirty graph log navigation

Pressing &lt;Enter> on any line shows the related commit (always in the same pseudopreview window)

Is based on AnsiEsc.vim to show colors, https://github.com/albfan/AnsiEsc.vim but ommiting "AnsiEsc" call and "--color=always" on git log command should be enough to test this (although less eye candy)

Aligning it with fugitive way to show commits, diffs, etc can be reworked if idea seems useful
