### PR TITLE
I killed the Beast!!!! I can now use Gcommit and Gmove in any buffer!!!

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -108,7 +108,7 @@ endfunction
 
 function! s:define_commands() abort
   for command in s:commands
-    exe 'command! -buffer '.command
+    exe 'command! '.command
   endfor
 endfunction
 

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1854,8 +1854,8 @@ endfunction
 augroup fugitive_remove
   autocmd!
   autocmd User Fugitive if s:buffer().commit() =~# '^0\=$' |
-        \ exe "command! -buffer -bar -bang -nargs=1 -complete=customlist,s:MoveComplete Gmove :execute s:Move(<bang>0,<q-args>)" |
-        \ exe "command! -buffer -bar -bang Gremove :execute s:Remove(<bang>0)" |
+        \ exe "command! -bar -bang -nargs=1 -complete=customlist,s:MoveComplete Gmove :execute s:Move(<bang>0,<q-args>)" |
+        \ exe "command! -bar -bang Gremove :execute s:Remove(<bang>0)" |
         \ endif
 augroup END
 


### PR DESCRIPTION
I removed `-buffer` from augroup fugitive_remove and s:define_commands()


Tested with markdown files

