### PR TITLE
Fix fileignorecase and wildignorecase detection on OS X vim

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -558,7 +558,7 @@ function! s:buffer_commit() dict abort
 endfunction
 
 function! s:cpath(path) abort
-  if exists('+fileignorecase') ? &fileignorecase : &wildignorecase
+  if (exists('+fileignorecase') && &fileignorecase) || (exists('+wildignorecase') && &wildignorecase)
     return tolower(a:path)
   else
     return a:path


### PR DESCRIPTION
Previously, this line caused an error on the version of vim that ships
with OS X (tested with OS X 10.10.4, vim 7.3). It appears that this
version of vim compiled and shipped with OS X supports neither
fileignorecase nor wildignorecase. Thus, this line was causing an error
when launching vim. The specific error was:

    E113: Unknown option: wildignorecase
    E15: Invalid expression: exists('+fileignorecase') ? &fileignorecase : &wildignorecase

This fix tweaks the conditional statement so that it runs properly if
neither option is present.

Signed-off-by: Michael Dippery <michael@monkey-robot.com>