### PR TITLE
Glob: stash references and fix special chars

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -404,6 +404,11 @@ function! s:repo_superglob(base) dict abort
     if a:base !~# '^/'
       let heads = ["HEAD","ORIG_HEAD","FETCH_HEAD","MERGE_HEAD"]
       let heads += sort(split(s:repo().git_chomp("rev-parse","--symbolic","--branches","--tags","--remotes"),"\n"))
+      " Add any stashes.
+      if filereadable(s:repo().dir('refs/stash'))
+        let heads += ["stash"]
+        let heads += sort(split(s:repo().git_chomp("stash","list","--pretty=format:%gd"),"\n"))
+      endif
       call filter(heads,'v:val[ 0 : strlen(a:base)-1 ] ==# a:base')
       let results += heads
     endif

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -424,7 +424,7 @@ function! s:repo_superglob(base) dict abort
 
   elseif a:base =~# '^:'
     let entries = split(self.git_chomp('ls-files','-z','--stage'),"")
-    call map(entries,'s:sub(v:val,".*(\\d)\\t(.*)",":\\1:\\2")')
+    call map(entries,'s:sub(v:val,".*(\\d)\\t(.*)","\\=\":\".submatch(1).\":\".fnameescape(submatch(2))")')
     if a:base !~# '^:[0-3]\%(:\|$\)'
       call filter(entries,'v:val[1] == "0"')
       call map(entries,'v:val[2:-1]')
@@ -436,7 +436,7 @@ function! s:repo_superglob(base) dict abort
     let tree = matchstr(a:base,'.*[:/]')
     let entries = split(self.git_chomp('ls-tree','-z',tree),"")
     call map(entries,'s:sub(v:val,"^04.*\\zs$","/")')
-    call map(entries,'tree.s:sub(v:val,".*\t","")')
+    call map(entries,'tree.fnameescape(s:sub(v:val,".*\t",""))')
     return filter(entries,'v:val[ 0 : strlen(a:base)-1 ] ==# a:base')
   endif
 endfunction
@@ -1407,7 +1407,7 @@ function! s:Edit(cmd,bang,...) abort
 endfunction
 
 function! s:EditComplete(A,L,P) abort
-  return map(s:repo().superglob(a:A), 'fnameescape(v:val)')
+  return s:repo().superglob(a:A)
 endfunction
 
 function! s:EditRunComplete(A,L,P) abort

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -423,7 +423,7 @@ function! s:repo_superglob(base) dict abort
     return results
 
   elseif a:base =~# '^:'
-    let entries = split(self.git_chomp('ls-files','--stage'),"\n")
+    let entries = split(self.git_chomp('ls-files','-z','--stage'),"")
     call map(entries,'s:sub(v:val,".*(\\d)\\t(.*)",":\\1:\\2")')
     if a:base !~# '^:[0-3]\%(:\|$\)'
       call filter(entries,'v:val[1] == "0"')
@@ -434,7 +434,7 @@ function! s:repo_superglob(base) dict abort
 
   else
     let tree = matchstr(a:base,'.*[:/]')
-    let entries = split(self.git_chomp('ls-tree',tree),"\n")
+    let entries = split(self.git_chomp('ls-tree','-z',tree),"")
     call map(entries,'s:sub(v:val,"^04.*\\zs$","/")')
     call map(entries,'tree.s:sub(v:val,".*\t","")')
     return filter(entries,'v:val[ 0 : strlen(a:base)-1 ] ==# a:base')


### PR DESCRIPTION
This adds globbing for `stash`, `stash@{0}` etc, and fixes the escaping of filesnames - especially for files that `git-ls-files`/`git-ls-trees` considers to be special (by using `-z`).