### PR TITLE
Allow using the "%" variable in git commands

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -683,7 +683,7 @@ function! s:Git(bang, args) abort
   let args = matchstr(a:args,'\v\C.{-}%($|\\@<!%(\\\\)*\|)@=')
   if exists(':terminal')
     let dir = s:repo().tree()
-    tabnew
+    tabedit %
     execute 'lcd' fnameescape(dir)
     execute 'terminal' git args
   else


### PR DESCRIPTION
Fixes issue #686

For example, when running:

  :Git add %

neovim throws the following exception:

  E499: Empty file name for '%' or '#',
  only works with ":p:h": terminal git add %

It is a result of the tabnew command, it creates a new blank tab where
"%" is empty.

This commit changes "tabnew" to "tabedit %" so you're still working on
the same file.

Once the command is done running the tab closes.