### PR TITLE
Fix diff sometimes opening in preview window

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1336,8 +1336,10 @@ function! s:Edit(cmd,bang,...) abort
       if winnr('$') == 1
         let tabs = (&go =~# 'e' || !has('gui_running')) && &stal && (tabpagenr('$') >= &stal)
         execute 'rightbelow' (&lines - &previewheight - &cmdheight - tabs - 1 - !!&laststatus).'new'
-      else
+      elseif winnr('#')
         wincmd p
+      else
+        wincmd w
       endif
       if &diff
         let mywinnr = winnr()


### PR DESCRIPTION
If the previous window no longer exists when Gedit is called, the attempt to change windows with 'wincmd p' fails and 'wincmd w' should be used instead. For example, if the preview window is 1, middle window is 2, and bottom window is 3  and closing window 3 makes window 1 active, `Gedit` will not switch to window 2 like it should.