### PR TITLE
Encode URLs before passing them to netrw

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2273,6 +2273,7 @@ function! s:Browse(bang,line1,count,...) abort
       call s:throw("Instaweb failed to start and '".remote."' is not a supported remote")
     endif
 
+    let url = s:url_encode(url)
     if a:bang
       if has('clipboard')
         let @* = url
@@ -2387,6 +2388,10 @@ function! s:instaweb_url(opts) abort
     let url .= '#l' . a:opts.line1
   endif
   return url
+endfunction
+
+function! s:url_encode(str)
+  return substitute(a:str,'[^A-Za-z0-9_.:/#~-]','\="%".printf("%02X",char2nr(submatch(0)))','g')
 endfunction
 
 if !exists('g:fugitive_browse_handlers')


### PR DESCRIPTION
This fixes a bug where characters such as # were escaped by netrw which 404s on GitHub