### PR TITLE
fix when $GIT_DIR is set and is not an absolute path

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -143,11 +143,11 @@ function! fugitive#extract_git_dir(path) abort
       break
     endif
     if root ==# $GIT_WORK_TREE && fugitive#is_git_dir($GIT_DIR)
-      return $GIT_DIR
+      return simplify(fnamemodify(expand($GIT_DIR), ':p:s?[\/]$??'))
     endif
     if fugitive#is_git_dir($GIT_DIR)
       " Ensure that we've cached the worktree
-      call s:configured_tree($GIT_DIR)
+      call s:configured_tree(simplify(fnamemodify(expand($GIT_DIR), ':p:s?[\/]$??')))
       if has_key(s:dir_for_worktree, root)
         return s:dir_for_worktree[root]
       endif


### PR DESCRIPTION
Hi Tim,

since some git version (I can't tell which one, it seems to not being explicitly described in their release notes), git exports GIT_DIR variable in alias command. At least, it appears with git 2.6

I have the current git alias:
> edit-modified = "!f() { git ls-files --modified | cut -f2 | sort -u ; }; vim `f`"

When I use
> git edit-modified

$GIT_DIR is set with a relative path

At the end, fugitive fails with error as:
> Error detected while processing function <SNR>49_Diff..<SNR>49_repo_git_chomp_in_tree:
line    4:
E344: Can't find directory "`=s:repo().tree()`" in cdpath
E472: Command failed
Error detected while processing function <SNR>49_Diff:
line    9:
E171: Missing :endif

The patch is a bit dirty, but I don't figure how to remove ain a simpler way the trailing /