### PR TITLE
Add `:Gtdiff` command(s) to open diff in a new tab

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -192,6 +192,16 @@ that are part of Git repositories).
                                                 *fugitive-:Gvdiff*
 :Gvdiff [revision]      Like |:Gdiff|, but always split vertically.
 
+                                                *fugitive-:Gtdiff*
+:Gtdiff [revision]      Like |:Gdiff|, but open the diff in a new tab before
+                        the current working tab.
+
+                                                *fugitive-:Gtsdiff*
+:Gtsdiff [revision]     Like |:Gtdiff|, but split the new tab horizontally.
+
+                                                *fugitive-:Gtvdiff*
+:Gtvdiff [revision]     Like |:Gtdiff|, but split the new tab vertically.
+
                                                 *fugitive-:Gmove*
 :Gmove {destination}    Wrapper around git-mv that renames the buffer
                         afterward.  The destination is relative to the current

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1687,6 +1687,9 @@ endfunction
 call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gdiff :execute s:Diff('',<bang>0,<f-args>)")
 call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gvdiff :execute s:Diff('keepalt vert ',<bang>0,<f-args>)")
 call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gsdiff :execute s:Diff('keepalt ',<bang>0,<f-args>)")
+call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gtdiff :execute tabpagenr() - 1 . 'tab split' | execute s:Diff('',<bang>0,<f-args>)")
+call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gtvdiff :execute tabpagenr() - 1 . 'tab split' | execute s:Diff('keepalt vert ',<bang>0,<f-args>)")
+call s:command("-bang -bar -nargs=* -complete=customlist,s:EditComplete Gtsdiff :execute tabpagenr() - 1 . 'tab split' | execute s:Diff('keepalt ',<bang>0,<f-args>)")
 
 augroup fugitive_diff
   autocmd!


### PR DESCRIPTION
As discussed in PR #413 and #319 this feature adds relevant command and
documentation to open Git diffs in new tab.

Note that like #413, the new tab is created before the current working tab.
After playing around for a while, it appears that closing the new diff tab
should take you back to the original working tab.
