### PR TITLE
Adds the U checkout shortcut in :Gstatus to docs

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -40,6 +40,7 @@ that are part of Git repositories).
                         <CR>  |:Gedit|
                         -     |:Git| add
                         -     |:Git| reset (staged files)
+                        U     |:Git| checkout --
                         cA    |:Gcommit| --amend --reuse-message=HEAD
                         ca    |:Gcommit| --amend
                         cc    |:Gcommit|


### PR DESCRIPTION
Just learned about the U shortcut for `git checkout -- [file]` by going on SO, but it wasn't in the docs. So, you know, here.