### PR TITLE
Fix :Gbrowse in "detached HEAD" state

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2330,10 +2330,16 @@ function! s:github_url(opts, ...) abort
   if a:opts.revision =~# '^[[:alnum:]._-]\+:'
     let commit = matchstr(a:opts.revision,'^[^:]*')
   elseif a:opts.commit =~# '^\d\=$'
-    let local = matchstr(a:opts.repo.head_ref(),'\<refs/heads/\zs.*')
-    let commit = a:opts.repo.git_chomp('config','branch.'.local.'.merge')[11:-1]
-    if commit ==# ''
-      let commit = local
+    let ref = a:opts.repo.head_ref()
+    let local = matchstr(ref,'\<refs/heads/\zs.*')
+    if !empty(local)
+      let commit = a:opts.repo.git_chomp('config','branch.'.local.'.merge')[11:-1]
+      if commit ==# ''
+        let commit = local
+      endif
+    else
+      let tag = a:opts.repo.git_chomp('describe','--exact-match','--tags')
+      let commit = v:shell_error ? ref : tag
     endif
   else
     let commit = a:opts.commit


### PR DESCRIPTION
Closes #646.

This patch tries to find the right URL for HEAD when in detached HEAD state. If there's a matching tag on HEAD (e.g. `git checkout v2.2`) it will use it, otherwise, SHA. This is my attempt to fix the issue without fully understanding the codebase, so maybe I'm doing something incredibly wrong here and if there's a better way to handle this, feel free to close this PR. Actually I couldn't figure out what `^\d\=$` is supposed to match, but I noticed that it matches empty string in detached HEAD state.