### PR TITLE
Don't use spaces in Git command to avoid problems under Windows

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2689,7 +2689,7 @@ function! s:BufReadObject() abort
         if b:fugitive_display_format
           call s:ReplaceCmd(s:repo().git_command('cat-file',b:fugitive_type,hash))
         else
-          call s:ReplaceCmd(s:repo().git_command('show','--no-color','--pretty=format:tree %T%nparent %P%nauthor %an <%ae> %ad%ncommitter %cn <%ce> %cd%nencoding %e%n%n%s%n%n%b',hash))
+          call s:ReplaceCmd(s:repo().git_command('show','--no-color','--pretty=format:tree%x20%T%nparent%x20%P%nauthor%x20%an%x20<%ae>%x20%ad%ncommitter%x20%cn%x20<%ce>%x20%cd%nencoding%x20%e%n%n%s%n%n%b',hash))
           keepjumps call search('^parent ')
           if getline('.') ==# 'parent '
             silent keepjumps delete_


### PR DESCRIPTION
When using a helper script to make Windows Vim work with Cygwin Git, arguments
containing spaces don't survive being passed through "cmd /c" to this script
and are decomposed into several tokens.

Just use "%x20" instead of spaces in the pretty format to avoid the problem.

---
I realize that this is an ugly fix and there may be some bug somewhere among `cmd.exe` invoking Cygwin shell to run my git wrapper script, but this is the only solution to make it work I could find after spending close to an hour on this, so I'd like to submit it just in case it can help somebody else.