### PR TITLE
Use "+ instead of "*

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2327,7 +2327,7 @@ function! s:Browse(bang,line1,count,...) abort
     let url = s:gsub(url, '[ <>]', '\="%".printf("%02X",char2nr(submatch(0)))')
     if a:bang
       if has('clipboard')
-        let @* = url
+        let @+ = url
       endif
       return 'echomsg '.string(url)
     elseif exists(':Browse') == 2


### PR DESCRIPTION
I'm guessing most people will expect "copy to clipboard" to mean the real clipboard, not the primary selection, when working under X11. I certainly did.

From the vim docs:

> *quoteplus* *quote+*
>
>There are three documented X11 selections: `PRIMARY`, `SECONDARY`, and `CLIPBOARD`. `CLIPBOARD` is typically used in X11 applications for copy/paste operations (`Ctrl-c`/`v`), while `PRIMARY` is used for the last selected text, which is generally inserted with the middle mouse button.
>
> Vim's X11 clipboard providers only utilize the `PRIMARY` and `CLIPBOARD` selections, used for the '*' and '+' registers, respectively.