### PR TITLE
Minor but convenient tabedit changes

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1089,7 +1089,7 @@ function! s:Commit(args, ...) abort
         if bufname('%') == '' && line('$') == 1 && getline(1) == '' && !&mod
           execute 'keepalt edit '.s:fnameescape(msgfile)
         elseif a:args =~# '\%(^\| \)-\%(-verbose\|\w*v\)\>'
-          execute 'keepalt '.(tabpagenr()-1).'tabedit '.s:fnameescape(msgfile)
+          execute 'keepalt -tabedit '.s:fnameescape(msgfile)
         elseif s:buffer().type() ==# 'index'
           execute 'keepalt edit '.s:fnameescape(msgfile)
           execute (search('^#','n')+1).'wincmd+'

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -704,7 +704,7 @@ function! s:Git(bang, args) abort
   let args = matchstr(a:args,'\v\C.{-}%($|\\@<!%(\\\\)*\|)@=')
   if exists(':terminal')
     let dir = s:repo().tree()
-    tabedit %
+    -tabedit %
     execute 'lcd' fnameescape(dir)
     execute 'terminal' git args
   else


### PR DESCRIPTION
It bothered me that the neovim `:terminal` strategy for `:Git` opens a new tab to the right of the current tab, instead of to the left, as `:Gcommit -v` does. It's much more convenient to open it to the left, because you'll end up back where you issued the command when you close the new tab.

While I was looking at the code, I noticed that `:Gcommit -v` uses `:exe (tabpagenr()-1).'tabedit'` in order to open its tab to the left; `:-tabedit` does the same thing cheaper, so I figured I'd change it first, while I was at it.