### PR TITLE
Fix for empty buffer :Git command in Neovim

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -700,7 +700,11 @@ function! s:Git(bang, args) abort
   let args = matchstr(a:args,'\v\C.{-}%($|\\@<!%(\\\\)*\|)@=')
   if exists(':terminal')
     let dir = s:repo().tree()
-    -tabedit %
+    if expand('%') != ''
+      -tabedit %
+    else
+      -tabnew
+    endif
     execute 'lcd' fnameescape(dir)
     execute 'terminal' git args
   else


### PR DESCRIPTION
Detects whether the current buffer is empty; opens a new empty tab if so, a new tab of the same buffer if not.

Fixes #783 
