### PR TITLE
Add Gtcd command

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -29,6 +29,9 @@ that are part of Git repositories).
                                                 *fugitive-:Glcd*
 :Glcd [directory]       |:lcd| relative to the repository.
 
+                                                *fugitive-:Gtcd*
+:Gtcd [directory]       |:tcd| relative to the repository. (Neovim only)
+
                                                 *fugitive-:Gstatus*
 :Gstatus                Bring up the output of git-status in the preview
                         window.  The following maps, which work on the cursor

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -728,7 +728,7 @@ function! s:GitComplete(A, L, P) abort
   endif
 endfunction
 
-" Section: Gcd, Glcd
+" Section: Gcd, Glcd, Gtcd
 
 function! s:DirComplete(A,L,P) abort
   let matches = s:repo().dirglob(a:A)
@@ -737,6 +737,11 @@ endfunction
 
 call s:command("-bar -bang -nargs=? -complete=customlist,s:DirComplete Gcd  :cd<bang>  `=s:repo().bare() ? s:repo().dir(<q-args>) : s:repo().tree(<q-args>)`")
 call s:command("-bar -bang -nargs=? -complete=customlist,s:DirComplete Glcd :lcd<bang> `=s:repo().bare() ? s:repo().dir(<q-args>) : s:repo().tree(<q-args>)`")
+
+" tcd support for neovim users
+if exists(':tcd')
+  call s:command("-bar -bang -nargs=? -complete=customlist,s:DirComplete Gtcd :tcd<bang> `=s:repo().bare() ? s:repo().dir(<q-args>) : s:repo().tree(<q-args>)`")
+endif
 
 " Section: Gstatus
 


### PR DESCRIPTION
`:tcd` was introduced to neovim on August 24th, 2015; this wraps it with `:Gtcd`. I didn't think it was necessary to check if `:tcd` exists, but if you think otherwise, I'll make it conditional.
