### PR TITLE
Gsdiff: split horizontally with diffopt+=vertical

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1858,6 +1858,10 @@ function! s:Diff(vert,keepfocus,...) abort
       setlocal cursorbind
     endif
     let w:fugitive_diff_restore = restore
+    if !empty(a:vert) && &diffopt =~# 'vertical' && a:vert !~# ' vert '
+      let l:diffopt_vert_removed = 1
+      set diffopt-=vertical
+    endif
     if s:buffer().compare_age(commit) < 0
       execute 'rightbelow '.vert.'diffsplit '.s:fnameescape(spec)
     else
@@ -1865,6 +1869,10 @@ function! s:Diff(vert,keepfocus,...) abort
     endif
     let &l:readonly = &l:readonly
     redraw
+    if exists('l:diffopt_vert_removed')
+      set diffopt+=vertical
+      unlet l:diffopt_vert_removed
+    endif
     let w:fugitive_diff_restore = restore
     let winnr = winnr()
     if getwinvar('#', '&diff')

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1806,7 +1806,6 @@ function! s:Diff(vert,keepfocus,...) abort
   if get(args, 0) =~# '^+'
     let post = remove(args, 0)[1:-1]
   endif
-  let vert = empty(a:vert) ? s:diff_modifier(2) : a:vert
   if exists(':DiffGitCached')
     return 'DiffGitCached'
   elseif (empty(args) || args[0] == ':') && s:buffer().commit() =~# '^[0-1]\=$' && s:repo().git_chomp_in_tree('ls-files', '--unmerged', '--', s:buffer().path()) !=# ''
@@ -1826,7 +1825,9 @@ function! s:Diff(vert,keepfocus,...) abort
     execute 'nnoremap <buffer> <silent> d2o :diffget '.nr2.'<Bar>diffupdate<CR>'
     execute 'nnoremap <buffer> <silent> d3o :diffget '.nr3.'<Bar>diffupdate<CR>'
     return post
-  elseif len(args)
+  endif
+  let vert = empty(a:vert) ? s:diff_modifier(2) : a:vert
+  if len(args)
     let arg = join(args, ' ')
     if arg ==# ''
       return post


### PR DESCRIPTION
With `set diffopt+=vertical` `Gsdiff` will not use a horizontal split,
because the effective command being run is `:leftabove keepalt diffsplit`.

This patch temporarily unsets the `vertical` option.

~~If this is considered to be good, then this should be done for the 3-way-diff, too.~~ (that does not use `diffsplit`, so it should be fine)
