### PR TITLE
Follow symlinks

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -140,12 +140,13 @@ function! fugitive#extract_git_dir(path) abort
   if s:shellslash(a:path) =~# '^fugitive://.*//'
     return matchstr(s:shellslash(a:path), '\C^fugitive://\zs.\{-\}\ze//')
   endif
+  let path = resolve(fnamemodify(a:path, ':p'))
   if isdirectory(a:path)
-    let path = fnamemodify(a:path, ':p:s?[\/]$??')
+    let path = fnamemodify(path, ':p:s?[\/]$??')
   else
-    let path = fnamemodify(a:path, ':p:h:s?[\/]$??')
+    let path = fnamemodify(path, ':p:h:s?[\/]$??')
   endif
-  let root = s:shellslash(resolve(path))
+  let root = s:shellslash(path)
   let previous = ""
   while root !=# previous
     if root =~# '\v^//%([^/]+/?)?$'
@@ -587,6 +588,9 @@ else
 
   function! s:buffer_spec() dict abort
     let bufname = bufname(self['#'])
+    if filereadable(bufname)
+      let bufname = resolve(bufname)
+    endif
     return s:shellslash(bufname == '' ? '' : fnamemodify(bufname,':p'))
   endfunction
 


### PR DESCRIPTION
Addresses issue #147
Works with vim-airline as well

@tpope, please check this out and see if you can break it. It's working fine for me, including with deep symlinks as @stardiviner suggested. An extra patch would likely be required for windows, but I have no easy way of testing that so this only fixes *nix systems. As far as I can tell, it shouldn't break the windows version (unless `resolve` does something weird on windows).
