### PR TITLE
ctag detection for submodules, recursive or otherwise

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -202,6 +202,9 @@ function! fugitive#detect(path) abort
       if filereadable(b:git_dir.'/tags')
         call buffer.setvar('&tags', escape(b:git_dir.'/tags', ', ').','.buffer.getvar('&tags'))
       endif
+      if isdirectory(b:git_dir.'/modules')
+        call buffer.setvar('&tags', buffer.getvar('&tags').','.escape(b:git_dir.'/modules/**/tags', ', '))
+      endif
       if &filetype !=# '' && filereadable(b:git_dir.'/'.&filetype.'.tags')
         call buffer.setvar('&tags', escape(b:git_dir.'/'.&filetype.'.tags', ', ').','.buffer.getvar('&tags'))
       endif


### PR DESCRIPTION
the strategy you specified @ http://tbaggery.com/2011/08/08/effortless-ctags-with-git.html is powerful, but doesn't work great with submodules, especially when vendoring libraries. As a solution, many people have replaced your canonical hooks:

```
#!/bin/sh
.git/hooks/ctags >/dev/null 2>&1 &
```

with

```
#!/bin/sh
$(git rev-parse --git-dir)/hooks/ctags >/dev/null 2>&1 &
```

so that automatically generated ctags store submodules' tags inside their parent's .git/modules/$submodule_dir/hooks/tags file.

this simple change recursively indexes and appends those submodule tag files such that their symbols are accessible from from their parent repository, giving the parent search order precedence for performance.

I'm running this inside a C++ tree that submodule vendors boost and qt, over 5GB of libraries, and it works great. If you have no submodules, there's no cost, either. 
