### PR TITLE
Use %delete_ to delete all the lines in the buffer

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1577,9 +1577,7 @@ function! s:Write(force,...) abort
         endif
         try
           let lnum = line('.')
-          let last = line('$')
-          silent execute '$read '.s:fnameescape(file)
-          silent execute '1,'.last.'delete_'
+          execute 'silent %delete_|silent read '.s:fnameescape(file).'|silent 1delete_'
           silent execute lnum
           set nomodified
           diffupdate


### PR DESCRIPTION
This is intended to fix #829 

I couldn't find a bug in the original approach (`$read '.s:fnameescape(file)`, then `'1,'.last.'delete_'`),  I don't see an issue in fugitive's code, maybe there's a bug in my version of vim.

But this alternative implementation is working fine: ` %delete_`, then `read '.s:fnameescape(file).'`, then `1delete_`.

Let me know if the PR can be improved.

Thanks for this plugin