### PR TITLE
Stricter match for fugitive:// buffers

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -195,7 +195,7 @@ function! fugitive#detect(path) abort
       nnoremap <buffer> <silent> y<C-G> :call setreg(v:register, <SID>recall())<CR>
     endif
     let buffer = fugitive#buffer()
-    if expand('%:p') =~# '//'
+    if expand('%:p') =~# '://'
       call buffer.setvar('&path', s:sub(buffer.getvar('&path'), '^\.%(,|$)', ''))
     endif
     if stridx(buffer.getvar('&tags'), escape(b:git_dir, ', ')) == -1


### PR DESCRIPTION
Fixes #871

It is valid - though odd - to open a file at `some//path`. In that case
the current check for fugitive buffers matches and changes &path
unexpectedly. A stricter match against `fugitive://` prevents this.