### PR TITLE
Add keybindings for interactive rebase

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -306,6 +306,24 @@ C                       Go to the commit containing the current file.
 a                       Show the current tag, commit, or tree in an alternate
                         format.
 
+                                                *fugitive-interactive-rebase*
+These maps are available during an interactive rebase, and change the command
+selected for the current line.
+
+I                       pick: use commit
+
+R                       reword: use commit, but edit the commit message
+
+E                       edit: use commit, but stop for amending
+
+S                       squash: use commit, but meld into previous commit
+
+F                       fixup: "squash", but discard this commit's log message
+
+X                       exec = run command (the rest of the line) using shell
+
+D                       drop = remove commit
+
 SPECIFYING REVISIONS                            *fugitive-revision*
 
 Fugitive revisions are similar to Git revisions as defined in the "SPECIFYING

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -3097,3 +3097,17 @@ augroup fugitive_foldtext
         \    set foldtext=fugitive#foldtext() |
         \ endif
 augroup END
+
+" Section: Interactive Rebase
+
+augroup fugitive_interactive_rebase
+  autocmd!
+  let b:fugitive_rebase_commands="^(pick|reword|edit|squash|fixup|exec|drop)"
+  autocmd FileType gitrebase nnoremap <buffer> <silent> I :s/\v<c-r>=b:fugitive_rebase_commands<cr>/pick/<cr>:nohlsearch<cr>
+  autocmd FileType gitrebase nnoremap <buffer> <silent> R :s/\v<c-r>=b:fugitive_rebase_commands<cr>/reword/<cr>:nohlsearch<cr>
+  autocmd FileType gitrebase nnoremap <buffer> <silent> E :s/\v<c-r>=b:fugitive_rebase_commands<cr>/edit/<cr>:nohlsearch<cr>
+  autocmd FileType gitrebase nnoremap <buffer> <silent> S :s/\v<c-r>=b:fugitive_rebase_commands<cr>/squash/<cr>:nohlsearch<cr>
+  autocmd FileType gitrebase nnoremap <buffer> <silent> F :s/\v<c-r>=b:fugitive_rebase_commands<cr>/fixup/<cr>:nohlsearch<cr>
+  autocmd FileType gitrebase nnoremap <buffer> <silent> X :s/\v<c-r>=b:fugitive_rebase_commands<cr>/exec/<cr>:nohlsearch<cr>
+  autocmd FileType gitrebase nnoremap <buffer> <silent> D :s/\v<c-r>=b:fugitive_rebase_commands<cr>/drop/<cr>:nohlsearch<cr>
+augroup END

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -3108,6 +3108,6 @@ augroup fugitive_interactive_rebase
   autocmd FileType gitrebase nnoremap <buffer> <silent> E :s/\v<c-r>=b:fugitive_rebase_commands<cr>/edit/<cr>:nohlsearch<cr>
   autocmd FileType gitrebase nnoremap <buffer> <silent> S :s/\v<c-r>=b:fugitive_rebase_commands<cr>/squash/<cr>:nohlsearch<cr>
   autocmd FileType gitrebase nnoremap <buffer> <silent> F :s/\v<c-r>=b:fugitive_rebase_commands<cr>/fixup/<cr>:nohlsearch<cr>
-  autocmd FileType gitrebase nnoremap <buffer> <silent> X :s/\v<c-r>=b:fugitive_rebase_commands<cr>/exec/<cr>:nohlsearch<cr>
+  autocmd FileType gitrebase nnoremap <buffer> <silent> X Oexec<space>
   autocmd FileType gitrebase nnoremap <buffer> <silent> D :s/\v<c-r>=b:fugitive_rebase_commands<cr>/drop/<cr>:nohlsearch<cr>
 augroup END


### PR DESCRIPTION
Hi Tim,

I've been using these keybindings for about two years and they've worked well. I realize this is a bit similar to PR #334, but I think the issue you had with that change was the map delays. It shouldn't be a problem with these bindings.

p **I** ck
**R** eword
**E** dit
**S** quash
**F** ixup
e **X** ec
**D** rop

I think these bindings are simpler, easy to remember and don't collide with any *useful* mappings for most editing of interactive rebases. They are simply the single letter version of the commands, but uppercase. The only exception is for "pick". `P` was too useful for editing, and I thought about using `K`, but `keywordprg` is also useful for viewing commit details. Since "pick" is the default command, usually it isn't necessary to change anyway.

For reference, this is the output from `git rebase -i`:

```
# Commands:
# p, pick = use commit
# r, reword = use commit, but edit the commit message
# e, edit = use commit, but stop for amending
# s, squash = use commit, but meld into previous commit
# f, fixup = like "squash", but discard this commit's log message
# x, exec = run command (the rest of the line) using shell
# d, drop = remove commit
```
I hope you consider merging this. It makes ripping through a rebase very quick and easy.

Cheers

-Tim
