### PR TITLE
Trigger Autocommands after changing windows from autocmd

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -748,8 +748,8 @@ call s:command("-bar Gstatus :execute s:Status()")
 augroup fugitive_status
   autocmd!
   if !has('win32')
-    autocmd FocusGained,ShellCmdPost * call fugitive#reload_status()
-    autocmd BufDelete term://* call fugitive#reload_status()
+    autocmd FocusGained,ShellCmdPost * call fugitive#reload_status(1)
+    autocmd BufDelete term://* call fugitive#reload_status(1)
   endif
 augroup END
 
@@ -765,7 +765,7 @@ function! s:Status() abort
   return ''
 endfunction
 
-function! fugitive#reload_status() abort
+function! fugitive#reload_status(...) abort
   if exists('s:reloading_status')
     return
   endif
@@ -795,6 +795,10 @@ function! fugitive#reload_status() abort
     endfor
   finally
     unlet! s:reloading_status
+    if exists('restorewinnr') && len(a:000)
+    " since autocommands do not nest, trigger WinEnter now
+      doauto WinEnter
+    endif
   endtry
 endfunction
 


### PR DESCRIPTION
By default autocommands do not nest and if fugitive#reload_status() is
called from an autocommand vim might switch windows internally to
refresh its status.

Unfortunately, after moving back to the original window, it does not
trigger the WinEnter autocommand and since airline depends on it to
display the correct statusline, the statusline highlighting will be
wrong.

Fix this by explicitly calling WinEnter autocommands, if windows have
been changed.

closes vim-airline/vim-airline#1452