### PR TITLE
Fix temp_files cache on Windows when TEMP is set to a short path

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1390,6 +1390,9 @@ function! s:Edit(cmd,bang,...) abort
       return 'redraw|echo '.string(':!'.git.' '.args)
     else
       let temp = resolve(tempname())
+      if has('win32')
+        let temp = fnamemodify(fnamemodify(temp, ':h'), ':p').fnamemodify(temp, ':t')
+      endif
       let s:temp_files[s:cpath(temp)] = { 'dir': buffer.repo().dir(), 'args': arglist }
       silent execute a:cmd.' '.temp
       if a:cmd =~# 'pedit'
@@ -2011,6 +2014,9 @@ function! s:Blame(bang,line1,line2,count,args) abort
         endif
         let top = line('w0') + &scrolloff
         let current = line('.')
+        if has('win32')
+          let temp = fnamemodify(fnamemodify(temp, ':h'), ':p').fnamemodify(temp, ':t')
+        endif
         let s:temp_files[s:cpath(temp)] = { 'dir': s:repo().dir(), 'args': cmd }
         exe 'keepalt leftabove vsplit '.temp
         let b:fugitive_blamed_bufnr = bufnr


### PR DESCRIPTION
If `%TEMP%` is set to a short path (e.g. "C:\LongDi~1") then `tempname()` will return a file name that contains that short path. If that path is later used as key for entry in `s:temp_files` dictionary, that entry won't be found in BufNewFile,BufReadPost events because `<afile>` is `expand()`'ed before it is used as a key for `s:temp_files`.
In the end, user gets cryptic error message about "C:\LongDirName\VI12345.tmp.fugitiveblame" not being a git repository when he tries to open a commit in Gblame window.

To workaround that we expand paths of temp files when adding entries to `s:temp_files`.