### PR TITLE
throw the joined errors if error is empty on commit

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1118,7 +1118,7 @@ function! s:Commit(args, ...) abort
       elseif error ==# '!'
         return s:Status()
       else
-        call s:throw(error)
+        call s:throw(error?error:join(errors, ' '))
       endif
     endif
   catch /^fugitive:/


### PR DESCRIPTION
This should fix #907.

Perhaps joining the whole errors array is a bit harsh but at least the user will have a full understanding of why git failed during the commit.

In the particular use case of the related bug, the message becomes:
`fugitive:  *** Please tell me who you are.  Run    git config --global user.email "you@example.com"   git config --global user.name "Your Name"  to set your account's default identity. Omit --global to set the identity only in this repository.  fatal: no name was given and auto-detection is disabled`