### PR TITLE
Support the master... format in :Gdiff

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -316,6 +316,7 @@ and the work tree file for everything else.  Example revisions follow.
 Revision        Meaning ~
 HEAD            .git/HEAD
 master          .git/refs/heads/master
+commit...       The common ancestor between commit and HEAD
 HEAD^{}         The commit referenced by HEAD
 HEAD^           The parent of the commit referenced by HEAD
 HEAD:           The tree referenced by HEAD

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1827,6 +1827,13 @@ function! s:Diff(vert,keepfocus,...) abort
       catch /^fugitive:/
         return 'echoerr v:errmsg'
       endtry
+    elseif arg =~# '[^.]\.\.\.$'
+        let base = s:repo().git_chomp('merge-base',matchstr(arg, '\S*[^.]'),'HEAD')
+        try
+            let file = s:repo().rev_parse(base).s:buffer().path(':')
+        catch /^fugitive:/
+            return 'echoerr v:errmsg'
+        endtry
     else
       let file = s:buffer().expand(arg)
     endif


### PR DESCRIPTION
It is implemented asking git what is the common ancestor between the
specified revision and the HEAD.
Closes #876