### PR TITLE
Add help for 'a' command in :Gstatus

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -40,6 +40,7 @@ that are part of Git repositories).
                         <CR>  |:Gedit|
                         -     |:Git| add
                         -     |:Git| reset (staged files)
+                        a     Show alternative format
                         cA    |:Gcommit| --amend --reuse-message=HEAD
                         ca    |:Gcommit| --amend
                         cc    |:Gcommit|


### PR DESCRIPTION
A couple times I ended up in `git show` mode in the `:Gstatus` window.  It took me a long time to figure out how I did it so I added it to the help.