### PR TITLE
Use https:// to clone

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,7 +66,7 @@ If you don't have a preferred installation method, one option is to install
 and paste:
 
     cd ~/.vim/bundle
-    git clone git://github.com/tpope/vim-fugitive.git
+    git clone https://github.com/tpope/vim-fugitive.git
     vim -u NONE -c "helptags vim-fugitive/doc" -c q
 
 If your Vim version is below 7.2, I recommend also installing


### PR DESCRIPTION
HTTPS is better supported in proxied corporate environments.