### PR TITLE
Resolve symlinks in repo().tree()

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -316,7 +316,7 @@ function! s:repo_tree(...) dict abort
   if dir ==# ''
     call s:throw('no work tree')
   else
-    return join([dir]+a:000,'/')
+    return join([resolve(dir)]+a:000,'/')
   endif
 endfunction
 


### PR DESCRIPTION
Linked worktrees in git have a .git file that references the main repo's
location with a string of the form

    gitdir: /a/b/c/.git/worktrees/myworktree

If one of the components of "/a/b/c" in this example is a symbolic link,
then :Gblame will fail in the worktree directory; a mismatch between
self.spec() and self.repo().tree() will cause buffer().path() to return
an empty string.

This problem is a pretty rare corner case; generally "git worktree add"
will resolve the pathname it writes to .git such that no symbolic links
are involved.  However if the directory structure is restructed *after*
worktree creation and symbolic links are used to keep old paths working,
this bug can be triggered.

For example, this bug could be triggered via a sequence of

	cd /foo/repo
	git worktree add ../worktree mybranch
	cd /
	mv foo bar
	ln -s bar foo

	cd /bar/worktree
	vim +Gblame myfile   # fails

	cd /foo/worktree
	vim +Gblame myfile   # also fails

Signed-off-by: Matt Roper <matthew.d.roper@intel.com>