### PR TITLE
Replace.cmd: make sure, the window stays the same

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2518,7 +2518,12 @@ function! s:ReplaceCmd(cmd,...) abort
     if fnamemodify(bufname('$'), ':p') ==# tmp
       silent execute 'bwipeout '.bufnr('$')
     endif
+    let winnr = winnr()
+    " might trigger a windo command (e.g. from the LargeFile plugin)
     silent exe 'doau BufReadPost '.s:fnameescape(fn)
+    if winnr != winnr()
+      exe "noa ".winnr."wincmd w"
+    endif
   endtry
 endfunction
 


### PR DESCRIPTION
If you view a large patch file from git, (e.g. from :Gblame), the large
file plugin might be triggered, which runs the NoMatchParen command,
which internally uses windo to iterate over all windows to disable match
parent highlighting.

However once the command has been run, we end up in the wrong window.
Now this is actually a bug in the match paren plugin or large file
plugin. But in any case add a check, that this does not cause a problem.

Simple test case with the vim repository: `vim runtime/doc/intro.txt +/Aaron`, `:Gblame` on the line with commit id `071d4279d6` press o. Notice you receive an error about `b:fugitive_type` being undefined and after that, note that the original buffer has been closed.