### PR TITLE
Do not accept :Gread count in argument position

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1486,7 +1486,7 @@ call s:command("-bar -bang -nargs=* -complete=customlist,s:EditRunComplete Gpedi
 call s:command("-bar -bang -nargs=* -complete=customlist,s:EditRunComplete Gsplit   :execute s:Edit('split',<bang>0,<f-args>)")
 call s:command("-bar -bang -nargs=* -complete=customlist,s:EditRunComplete Gvsplit  :execute s:Edit('vsplit',<bang>0,<f-args>)")
 call s:command("-bar -bang -nargs=* -complete=customlist,s:EditRunComplete Gtabedit :execute s:Edit('tabedit',<bang>0,<f-args>)")
-call s:command("-bar -bang -nargs=* -count -complete=customlist,s:EditRunComplete Gread :execute s:Edit((!<count> && <line1> ? '' : <count>).'read',<bang>0,<f-args>)")
+call s:command("-bar -bang -nargs=* -range=-1 -complete=customlist,s:EditRunComplete Gread :execute s:Edit((<count> == -1 ? '' : <count>).'read',<bang>0,<f-args>)")
 
 " Section: Gwrite, Gwq
 


### PR DESCRIPTION
Use `-range=0` instead of `-count` to prevent Vim from interpreting a
branch name starting with a number as a count, e.g. `:Gread 123-foo`
being interpreted as `:123Gread -foo`.