### PR TITLE
Added git checkout --theirs/--ours support for Gstatus

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -69,6 +69,8 @@ that are part of Git repositories).
                         X     |:Git| clean (untracked files)
                         X     |:Git| rm (unmerged files)
                         q     close status
+                        st    |:Git| checkout --theirs && git add (unmerged files)
+                        so    |:Git| checkout --ours && git add (unmerged files)
                         R     reload status
                         .     enter |:| command line with file prepopulated
 


### PR DESCRIPTION
When merging conflicting files using `git checkout --theirs/--ours file && git add file` is a very popular command, so much that some people we have an alias for this operation. Why not having it in the _fugitive_ `:Gstatus` window. 

If we include this feature, many of us does not have to leave VIM to perform this operation, we can easily just press one key stroke in each of the files.

Note that I am not a experienced _vimscript_ developer. My small hackish function just works in my configuration, it might not work in other configurations.

I updated the docs as well.