### PR TITLE
Allow custom fugitive#statusline prefix and suffix

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -346,6 +346,9 @@ a statusline, this one matches the default when 'ruler' is set:
 >
     set statusline=%<%f\ %h%m%r%{fugitive#statusline()}%=%-14.(%l,%c%V%)\ %P
 <
+Two optional parameters can be given to define a custom prefix and suffix for
+the indicator.
+
                                                 *fugitive#head(...)*
 Use fugitive#head() to return the name of the current branch. If the current
 HEAD is detached, fugitive#head() will return the empty string, unless the

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -3056,7 +3056,9 @@ function! fugitive#statusline(...) abort
     let status .= ':' . s:buffer().commit()[0:7]
   endif
   let status .= '('.fugitive#head(7).')'
-  if &statusline =~# '%[MRHWY]' && &statusline !~# '%[mrhwy]'
+  if a:0
+    return a:1.status.(a:0 > 1 ? a:2 : '')
+  elseif &statusline =~# '%[MRHWY]' && &statusline !~# '%[mrhwy]'
     return ',GIT'.status
   else
     return '[Git'.status.']'


### PR DESCRIPTION
    fugitive#statusline('[',']')

outputs, for example

    [:7c9b87a(master)]

The suffix parameter is optional. If no parameters are given, the
original logic is applied.