### PR TITLE
s:BufReadObject: catch rev-parse errors and assume empty object

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2748,6 +2748,8 @@ function! s:BufReadObject() abort
     endtry
 
     return ''
+  catch /^fugitive: rev-parse/
+    return ''
   catch /^fugitive:/
     return 'echoerr v:errmsg'
   endtry


### PR DESCRIPTION
With `:Gdiff ^` on a file that has just been added, you would get an
error via `git rev-parse --verify`:

> fatal: Needed a single revision

The error message is clearer when not using `--verify`:

> fatal: Path 'X' exists on disk, but not in 'SHA'.

The behavior depends on if you use `:set hidden`, where the second
invocation works, as in will open an empty buffer - apparently since it
has been created as "a buffer with read errors" ("x" in `:ls!`) before.

Fixes https://github.com/tpope/vim-fugitive/issues/866.