### PR TITLE
Add Gbrowse returning shortened URL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,7 +90,7 @@ directory.  Edit a file from the repository.
 
 `:Gbrowse` delegates to `git web--browse`, which is less than perfect
 when it comes to finding the right browser.  You can tell it the correct
-browser to use with `git config --global web.browser ...`.  On macOS, for
+browser to use with `git config --global web.browser ...`.  On OS X, for
 example, you might want to set this to `open`.  See `git web--browse --help`
 for details.
 


### PR DESCRIPTION
When communicating over IRC with somebody and I want to point him to
some particular piece of code, it would be useful if Gbrowse added to
the clipboard **shortened** URL of the code in question.

This PR adds such functionality. It is switched off per default and it
could be enabled by settings global variable
``g:fugitive_short_shorten`` to 1.

In case the extension is used inside of the corporate network and
internal addresses should not be leaked to the public URL shorteners,
one could set up dictionary ``g:fugitive_short_private_domains`` with
key being string which matches all domains inside of the private
network, and value is URL of the internal URL shortener. If this
dictionary is not set, the script uses ``https://da.gd/s?url=`` as
default.

For example, inside of the Red Hat network one can have in her
``~/.vimrc``

```viml
let g:fugitive_short_shorten = 1
let g:fugitive_short_private_domains = {}
let g:fugitive_short_private_domains['redhat.com'] =
    \ 'https://url.corp.redhat.com/new?'
```