### PR TITLE
Fix Gblame not being able to show any specific commit on Windows

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2479,6 +2479,9 @@ call extend(g:fugitive_browse_handlers,
 function! s:ReplaceCmd(cmd,...) abort
   let fn = expand('%:p')
   let tmp = tempname()
+  if has('win32')
+    let tmp = fnamemodify(fnamemodify(tmp, ':h'), ':p').fnamemodify(tmp, ':t')
+  endif
   let prefix = ''
   try
     if a:0 && a:1 != ''


### PR DESCRIPTION
This is adding the same fix that 4f24757df2a57fc01900334114b1790fcb75ad54 did,
but this time to ReplaceCmd.

The problem was that expand() can't expand short paths if the file doesn't
exist. So we split it in head and tail, and expand the head.