### PR TITLE
Using NERDTree.root instead of removed NERDTreeRoot command

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -241,7 +241,7 @@ augroup fugitive
   autocmd!
   autocmd BufNewFile,BufReadPost * call fugitive#detect(expand('%:p'))
   autocmd FileType           netrw call fugitive#detect(expand('%:p'))
-  autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTreeRoot.path.str())
+  autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTree.root.path.str())
   autocmd VimEnter * if expand('<amatch>')==''|call fugitive#detect(getcwd())|endif
   autocmd CmdWinEnter * call fugitive#detect(expand('#:p'))
   autocmd BufWinLeave * execute getwinvar(+bufwinnr(+expand('<abuf>')), 'fugitive_leave')


### PR DESCRIPTION
As of https://github.com/scrooloose/nerdtree/commit/d36b7936566f9913a0fa3925ba57214f17f302a3, it was recommended to use `NERDTree.root` instead of deprecated `NERDTreeRoot`. Also, this command seems to be recently removed since it was throwing an `Undefined variable: b:NERDTreeRoot` when starting Vim.