### PR TITLE
Use NERDTree.root instead of deprecated NERDTreeRoot

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -241,7 +241,12 @@ augroup fugitive
   autocmd!
   autocmd BufNewFile,BufReadPost * call fugitive#detect(expand('%:p'))
   autocmd FileType           netrw call fugitive#detect(expand('%:p'))
-  autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTreeRoot.path.str())
+  if exists("b:NERDTree.root")
+    autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTree.root.path.str())
+  elseif exists("b:NERDTReeRoot")
+    " for backwards compatibility with older versions of NERDTree
+    autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTreeRoot.path.str())
+  endif
   autocmd VimEnter * if expand('<amatch>')==''|call fugitive#detect(getcwd())|endif
   autocmd CmdWinEnter * call fugitive#detect(expand('#:p'))
   autocmd BufWinLeave * execute getwinvar(+bufwinnr(+expand('<abuf>')), 'fugitive_leave')

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -243,7 +243,7 @@ augroup fugitive
   autocmd FileType           netrw call fugitive#detect(expand('%:p'))
   if exists("b:NERDTree.root")
     autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTree.root.path.str())
-  elseif exists("b:NERDTReeRoot")
+  elseif exists("b:NERDTreeRoot")
     " for backwards compatibility with older versions of NERDTree
     autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTreeRoot.path.str())
   endif


### PR DESCRIPTION
Looks like NERDTree depcrecated NERDTreeRoot and briefly removed it. They added it back as a copy of NERDTree.root (the correct variable) with a note that it should be removed in later versions. Let's use the correct variable in case they remove it again