### PR TITLE
WIP:Fix assumption resulting in wrong tree location

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -305,14 +305,7 @@ function! s:configured_tree(git_dir) abort
 endfunction
 
 function! s:repo_tree(...) dict abort
-  if self.dir() =~# '/\.git$'
-    let dir = self.dir()[0:-6]
-    if dir !~# '/'
-      let dir .= '/'
-    endif
-  else
-    let dir = s:configured_tree(self.git_dir)
-  endif
+  let dir = s:configured_tree(self.git_dir)
   if dir ==# ''
     call s:throw('no work tree')
   else


### PR DESCRIPTION
Don't assume that because the repo().dir() ends with /.git, that one
level up from that is the .tree().

Closes #776