### PR TITLE
Fix laggy blame scrolling

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -2202,27 +2202,29 @@ function! s:BlameSyntax() abort
   hi def link FugitiveblameShort              FugitiveblameDelimiter
   hi def link FugitiveblameDelimiter          Delimiter
   hi def link FugitiveblameNotCommittedYet    Comment
-  if (&t_Co > 16 || has('gui_running')) && get(g:, 'CSApprox_loaded') && !empty(findfile('autoload/csapprox/per_component.vim', escape(&rtp, ' ')))
-    let seen = {}
-    for lnum in range(1, line('$'))
-      let hash = matchstr(getline(lnum), '^\^\=\zs\x\{6\}')
-      if hash ==# '' || hash ==# '000000' || has_key(seen, hash)
-        continue
-      endif
-      let seen[hash] = 1
-      if empty(get(s:hash_colors, hash))
-        let [s, r, g, b; __] = map(matchlist(hash, '\(\x\x\)\(\x\x\)\(\x\x\)'), 'str2nr(v:val,16)')
-        let color = csapprox#per_component#Approximate(r, g, b)
-        if color == 16 && &background ==# 'dark'
-          let color = 8
-        endif
-        let s:hash_colors[hash] = ' ctermfg='.color
-      else
-        let s:hash_colors[hash] = ''
-      endif
-      exe 'syn match FugitiveblameHash'.hash.'       "\%(^\^\=\)\@<='.hash.'\x\{1,34\}\>" nextgroup=FugitiveblameAnnotation,FugitiveblameOriginalLineNumber,fugitiveblameOriginalFile skipwhite'
-    endfor
-    call s:RehighlightBlame()
+  if get(g:, 'fugitive_dynamic_colors', 1)
+	if (&t_Co > 16 || has('gui_running')) && get(g:, 'CSApprox_loaded') && !empty(findfile('autoload/csapprox/per_component.vim', escape(&rtp, ' ')))
+	  let seen = {}
+	  for lnum in range(1, line('$'))
+		let hash = matchstr(getline(lnum), '^\^\=\zs\x\{6\}')
+		if hash ==# '' || hash ==# '000000' || has_key(seen, hash)
+		  continue
+		endif
+		let seen[hash] = 1
+		if empty(get(s:hash_colors, hash))
+		  let [s, r, g, b; __] = map(matchlist(hash, '\(\x\x\)\(\x\x\)\(\x\x\)'), 'str2nr(v:val,16)')
+		  let color = csapprox#per_component#Approximate(r, g, b)
+		  if color == 16 && &background ==# 'dark'
+			let color = 8
+		  endif
+		  let s:hash_colors[hash] = ' ctermfg='.color
+		else
+		  let s:hash_colors[hash] = ''
+		endif
+		exe 'syn match FugitiveblameHash'.hash.'       "\%(^\^\=\)\@<='.hash.'\x\{1,34\}\>" nextgroup=FugitiveblameAnnotation,FugitiveblameOriginalLineNumber,fugitiveblameOriginalFile skipwhite'
+	  endfor
+	  call s:RehighlightBlame()
+	endif
   endif
 endfunction
 


### PR DESCRIPTION
Don't add syntax groups for the blame "eye candy" from #369 unless we have the plugin to support it.

This speeds up highlighting if you don't have the plugin, since it doesn't make a group for each commit ID in the blame view.

When `&cursorline` was set, this feature caused CPU usage to max out while scrolling via spamming j/k.

In lieu of optimizing the syntax highlighting definition, or even turning it off with yet-another-config-variable, just omit adding the highlighting if adding them would effectively just create redundant highlight groups.
  