### PR TITLE
Fix Gsdiff not always opening horizontal split

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1859,11 +1859,13 @@ function! s:Diff(vert,keepfocus,...) abort
       setlocal cursorbind
     endif
     let w:fugitive_diff_restore = restore
+    call s:diffthis()
     if s:buffer().compare_age(commit) < 0
-      execute 'rightbelow '.vert.'diffsplit '.s:fnameescape(spec)
+      execute 'rightbelow '.vert.'split '.s:fnameescape(spec)
     else
-      execute 'leftabove '.vert.'diffsplit '.s:fnameescape(spec)
+      execute 'leftabove '.vert.'split '.s:fnameescape(spec)
     endif
+    call s:diffthis()
     let &l:readonly = &l:readonly
     redraw
     let w:fugitive_diff_restore = restore


### PR DESCRIPTION
Fixes issue #990 

```diffsplit``` obeys ```diffopt=vertical```, therefore use ```split``` and ```diffthis```, just like in the case where ```Gsdiff``` was called without arguments.