### PR TITLE
Open files in a modifiable buffer, if possible

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1424,11 +1424,19 @@ function! s:Edit(cmd,bang,...) abort
   let buffer = s:buffer()
   if a:cmd !~# 'read'
     if &previewwindow && getbufvar('','fugitive_type') ==# 'index'
+      let prev_winnr = winnr('#')
       if winnr('$') == 1
         let tabs = (&go =~# 'e' || !has('gui_running')) && &stal && (tabpagenr('$') >= &stal)
         execute 'rightbelow' (&lines - &previewheight - &cmdheight - tabs - 1 - !!&laststatus).'new'
-      elseif winnr('#')
+      elseif prev_winnr
         wincmd p
+        let skipbufs = ['nofile','help','quickfix']
+        while &previewwindow || index(skipbufs, &buftype) >= 0
+          wincmd w
+          if winnr() ==# prev_winnr
+            break
+          endif
+        endwhile
       else
         wincmd w
       endif


### PR DESCRIPTION
Sometimes I will either invoke, or jump to, the `Gstatus` window from an unmodifiable buffer which are almost always other plugins.  Then when I hit `o` to open a file, it opens the file in the plugin's window.
This is a mid-level inconvenience by me.

This patch will try and find a modifiable buffer to use if `winnr('#')` is `nomodifiable`.  If it can't, it will just use `winnr('#')` anyway.

This is definitely self-serving for my own plugin but happens from time to time with other plugins as well (like nerdtree).