### PR TITLE
Add hook at commit error

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -1136,6 +1136,9 @@ function! s:Commit(mods, args, ...) abort
       elseif error ==# '!'
         return s:Status()
       else
+        if exists('*FugitiveCommitError')
+          call FugitiveCommitError(error, errorfile)
+        endif
         call s:throw(empty(error)?join(errors, ' '):error)
       endif
     endif


### PR DESCRIPTION
## Summary
A hook was added to use the error output when a commit error occurred.
Because I wanted to add pre-commit error part to qflist.
Error output such as pre-commit differs depending on the user, so we can make analytical program in each.
I think that users flexibly use various ways.

## Usage Example

1. `git clone https://github.com/potato4d/pre-commit-sample`
2. `cd pre-commit-sample && npm install`
3. Edit `index.js`. Change `const Name` to `var Name`
5. Run `:Gcommit`. Then only an error is displayed.
6. Add the following code to .vimrc.
```vim
function FugitiveCommitError(error, tmpfile)
  if a:error =~? 'pre-commit'
    call s:applyQflist(a:tmpfile)
  endif
endfunction

function! s:applyQflist(tmpfile)
  let errors = []
  let contents = readfile(a:tmpfile)

  let filepath = ''
  for content in contents
    if empty(content)
      continue
    endif

    if content =~? '^/' && filereadable(content)
      let filepath = content
      continue
    endif

    if content =~? '\v\s*[0-9]+:[0-9]+'
      let csp = split(content)
      call add(errors, filepath . ':' . csp[0] . ':' . join(csp[2:-2], ' ') . '. [' . csp[-1] . ']')
    endif
  endfor

  setlocal errorformat=%f:%l:%c:%m
  cgetexpr join(errors, "\n")
  copen
endfunction
```
7. After reloading `.vimrc`, once again `Gcommit`, qflist of the error part is displayed.