### PR TITLE
Small tweak to improve fugitive-netrw interaction

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -276,7 +276,7 @@ endfunction
 augroup fugitive
   autocmd!
   autocmd BufNewFile,BufReadPost * call fugitive#detect(expand('%:p'))
-  autocmd FileType           netrw call fugitive#detect(expand('%:p'))
+  autocmd FileType           netrw call fugitive#detect(fnamemodify(get(b:, 'netrw_curdir', @%), ':p'))
   autocmd User NERDTreeInit,NERDTreeNewRoot call fugitive#detect(b:NERDTree.root.path.str())
   autocmd VimEnter * if expand('<amatch>')==''|call fugitive#detect(getcwd())|endif
   autocmd CmdWinEnter * call fugitive#detect(expand('#:p'))


### PR DESCRIPTION
Sometimes netrw does not always set % correctly, e.g. for the first directory opened (such as `vim .` or `:e /some/path` with `set hidden`, whereas it is set after navigating within netrw), so this PR gets the directory opened in netrw from `b:netrw_curdir` instead. I reported the bug to vim, but this should work for all versions of netrw/vim.

From netrw's documentation (about *g:netrw_keepdir*):

	The current browsing directory is contained in
	b:netrw_curdir (also see |netrw-c|)

This means that instead of opening a random file in a repo to start fugitive we can open the directory instead (at least anyone using `set hidden`).