### PR TITLE
Specify 'nofile' to status buffer and blame buffer

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -698,7 +698,7 @@ function! s:Status(bang, count, mods) abort
   try
     exe (a:mods ==# '<mods>' ? '' : a:mods) 'Gpedit :'
     wincmd P
-    setlocal foldmethod=syntax foldlevel=1
+    setlocal foldmethod=syntax foldlevel=1 buftype=nowrite
     nnoremap <buffer> <silent> q    :<C-U>bdelete<CR>
   catch /^fugitive:/
     return 'echoerr v:errmsg'
@@ -2004,7 +2004,7 @@ function! s:Blame(bang,line1,line2,count,args) abort
         if exists('+cursorbind')
           setlocal cursorbind
         endif
-        setlocal nomodified nomodifiable nonumber scrollbind nowrap foldcolumn=0 nofoldenable winfixwidth filetype=fugitiveblame
+        setlocal nomodified nomodifiable nonumber scrollbind nowrap foldcolumn=0 nofoldenable winfixwidth filetype=fugitiveblame buftype=nowrite
         if exists('+concealcursor')
           setlocal concealcursor=nc conceallevel=2
         endif


### PR DESCRIPTION
Since status buffer and blame buffer are not related to file and don't intend to be modified, buffer type should be 'nofile' I think. This is useful for me because I'm defining a mapping which closes 'nofile' buffers and it can also close fugitive's buffers when they are marked as 'nofile'.