### PR TITLE
Minor spelling error in help document

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -89,7 +89,7 @@ that are part of Git repositories).
 
                                                 *fugitive-:Grebase*
 :Grebase [args]         Like |:Gmerge|, but for git-rebase.  Interactive
-                        rebase not suppported.
+                        rebase not supported.
 
                                                 *fugitive-:Gpush*
 :Gpush [args]           Invoke git-push, load the results into the |quickfix|


### PR DESCRIPTION
I'd love to read the whole thing to see if there's any more tiny things like this, but oh well.