### PR TITLE
s:ReplaceCmd: use bwipeout on the tmp bufname directly

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -1174,9 +1174,7 @@ function! s:ReplaceCmd(cmd) abort
     catch /^Vim\%((\a\+)\)\=:E302:/
     endtry
     call delete(tmp)
-    if fnamemodify(bufname('$'), ':p') ==# tmp
-      silent execute 'bwipeout '.bufnr('$')
-    endif
+    silent execute 'bwipeout '.s:fnameescape(tmp)
     silent exe 'doau BufReadPost '.s:fnameescape(fn)
   endtry
 endfunction


### PR DESCRIPTION
When using "bash" as shell on Windows Vim, `tempname()` will return a
path with forward slashes, while fnamemodify+bufname use backward
slashes.

Using `s:tempname` for tmp results in mixed forward and backward
slashes (`C:/msys64/tmp\VIGCB01.tmp`).