### PR TITLE
Show stderr output for commit hooks

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2011,7 +2011,11 @@ function! s:Commit(mods, args, ...) abort
       elseif a:args =~# '\%(^\| \)-\%(-interactive\|p\|-patch\)\>'
         noautocmd execute '!'.command.' 2> '.errorfile
       else
-        noautocmd silent execute '!'.command.' > '.outfile.' 2> '.errorfile
+        if executable('tee') && &shell =~# 'bash\|zsh'
+          noautocmd silent execute '!'.command.' > '.outfile.' 2> >(tee '.errorfile.')'
+        else
+          noautocmd silent execute '!'.command.' > '.outfile.' 2> '.errorfile
+        endif
       endif
       let error = v:shell_error
     finally


### PR DESCRIPTION
Currently, during pre/post commit hooks there is only silence in a console. With this patch issues #985, #621, #355 and #95 are going to be fixed.