### PR TITLE
Support Grebase --continue/--edit-todo editor invocation

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2336,7 +2336,7 @@ let s:common_efm = ''
 
 function! s:Merge(cmd, bang, mods, args) abort
   let mods = substitute(a:mods, '\C<mods>', '', '') . ' '
-  if a:cmd =~# '^rebase' && ' '.a:args =~# ' -i\| --interactive\| --edit-todo'
+  if a:cmd =~# '^rebase' && ' '.a:args =~# ' -i\| --interactive'
     return 'echoerr "git rebase --interactive not supported"'
   endif
   let [mp, efm] = [&l:mp, &l:efm]
@@ -2398,6 +2398,8 @@ function! s:Merge(cmd, bang, mods, args) abort
     elseif a:cmd =~# '^rebase' && ' '.a:args =~# ' --continue' && s:HasRebaseCommitCmd()
       cclose
       return mods . 'Gcommit --amend'
+    elseif a:cmd =~# '^rebase' && ' '.a:args =~# ' --edit-todo'
+      return mods . 'Gsplit ' . s:fnameescape(b:git_dir . '/rebase-merge/git-rebase-todo') . ' | setlocal bufhidden=wipe nobuflisted'
     endif
   endif
   let qflist = getqflist()

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2308,6 +2308,13 @@ function! s:RemoteComplete(A, L, P) abort
   return join(matches, "\n")
 endfunction
 
+function! s:HasRebaseCommitCmd() abort
+  if !filereadable(b:git_dir . '/rebase-merge/amend') || !filereadable(b:git_dir . '/rebase-merge/done')
+    return 0
+  endif
+  return get(readfile(b:git_dir . '/rebase-merge/done'), -1, '') =~# '^[^e]'
+endfunction
+
 function! fugitive#Cwindow() abort
   if &buftype == 'quickfix'
     cwindow
@@ -2345,6 +2352,7 @@ function! s:Merge(cmd, bang, mods, args) abort
           \ . '%+ECannot %.%#: Your index contains uncommitted changes.,'
           \ . '%+EThere is no tracking information for the current branch.,'
           \ . '%+EYou are not currently on a branch. Please specify which,'
+          \ . '%+I%.%#git rebase --continue,'
           \ . 'CONFLICT (%m): %f deleted in %.%#,'
           \ . 'CONFLICT (%m): Merge conflict in %f,'
           \ . 'CONFLICT (%m): Rename \"%f\"->%.%#,'
@@ -2383,10 +2391,13 @@ function! s:Merge(cmd, bang, mods, args) abort
     execute cdback
   endtry
   call fugitive#ReloadStatus()
-  if empty(filter(getqflist(),'v:val.valid'))
+  if empty(filter(getqflist(),'v:val.valid && v:val.type !=# "I"'))
     if !had_merge_msg && filereadable(b:git_dir . '/MERGE_MSG')
       cclose
       return mods . 'Gcommit --no-status -n -t '.s:shellesc(b:git_dir . '/MERGE_MSG')
+    elseif a:cmd =~# '^rebase' && ' '.a:args =~# ' --continue' && s:HasRebaseCommitCmd()
+      cclose
+      return mods . 'Gcommit --amend'
     endif
   endif
   let qflist = getqflist()


### PR DESCRIPTION
As discussed in #797 

`copen` was decided as the method of feedback for the user on `Grebase --continue` because `cwindow` obfuscates user feedback.

The exact method for `--edit-todo` discussed was not used. You don't need to copy the file, edit it, and move it back. You just need to edit the file. The only difference between this and invoking `--edit-todo` via the command line is that the commit hashes are not contracted and expanded. This requires using `git rebase--interactive --expand-ids` and `git rebase--interactive --shorten-ids`, which are internal helpers and can't be relied on to remain publicly accessible.

`Grebase --edit-todo` does not yet support window mods but it easily can. Let me know if you think this is needed now.

I also believe that it would be useful to have `--continue` and `--edit-todo` rebase autocompletion. This is another thing that can easily be added if you think it should be part of this PR.