### PR TITLE
Provide path and line to :Gbrowse providers for commits

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3926,6 +3926,21 @@ function! s:Browse(bang,line1,count,...) abort
       endwhile
     endif
 
+    if type ==# 'commit' && a:count && getline('.') =~# '^[ +-]' && search('^@@ -\d\+\%(,\d\+\)\= +\d\+','bnW')
+      let sigil = getline('.')[0] ==# '-' ? '-' : '+'
+      let lnum = line('.') - 1
+      let offset = 0
+      while getline(lnum) !~# '^@@ -\d\+\%(,\d\+\)\= +\d\+'
+        if getline(lnum) =~# '^[ '.sigil.']'
+          let offset += 1
+        endif
+        let lnum -= 1
+      endwhile
+      let offset += matchstr(getline(lnum), sigil.'\zs\d\+')
+      let path = getline(search('^\(+++\|---\) [abciow12]/','bnW'))[6:-1]
+      let line1 = sigil ==# '-' ? -offset : offset
+    endif
+
     if empty(remote)
       let remote = '.'
     endif


### PR DESCRIPTION
Look for and use path of the +++ side when it exists. For removals it is
/dev/null, so use path of the  --- side. For the line range only line1
is set, corresponding to the first line of selected region. If this line
is in the removed part of the hunk, the number is relative to the ---
side and is negative to indicate that to adapters.