### PR TITLE
Add `g:fugitive_replace_status_on_commit` option

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2495,6 +2495,10 @@ function! s:Commit(mods, args, ...) abort
           execute mods 'keepalt edit' s:fnameescape(msgfile)
         elseif a:args =~# '\%(^\| \)-\w*v' || mods =~# '\<tab\>'
           execute mods 'keepalt -tabedit' s:fnameescape(msgfile)
+        elseif get(g:, 'fugitive_replace_status_on_commit') && get(b:, 'fugitive_type', '') ==# 'index'
+          execute mods 'keepalt edit' s:fnameescape(msgfile)
+          execute (search('^#','n')+1).'wincmd+'
+          setlocal nopreviewwindow
         else
           execute mods 'keepalt split' s:fnameescape(msgfile)
         endif

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -83,6 +83,11 @@ that are part of Git repositories).
                         commands like git-add and git-reset while a commit
                         message is pending.
 
+                                      *g:fugitive_replace_status_on_commit*
+Global option to replace the |:Gstatus| window when performing |:Gcommit|.
+To enable |:Gcommit| view replacement: >
+    let g:fugitive_replace_status_on_commit = 1
+<
                                                 *fugitive-:Gmerge*
 :Gmerge [args]          Calls git-merge and loads errors and conflicted files
                         into the |quickfix| list.  Opens a |:Gcommit| style


### PR DESCRIPTION
Option defaults to disabled/unset.
When enabled, the pre-Dec 2019 behaviour of :Gcommit taking over
:Gstatus will occur.

Related to https://github.com/tpope/vim-fugitive/commit/a32c301f516cf64e5a8e28ad106923e8cee5cda3