### PR TITLE
Move filetype to after maps to allow user maps

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -1521,7 +1521,6 @@ function! fugitive#BufReadStatus() abort
 
     set nomodified readonly noswapfile
     silent doautocmd BufReadPost
-    set filetype=fugitive
     setlocal nomodifiable
     if &bufhidden ==# ''
       setlocal bufhidden=delete
@@ -1574,6 +1573,7 @@ function! fugitive#BufReadStatus() abort
     nnoremap <buffer> <silent> q    :<C-U>bdelete<CR>
     nnoremap <buffer> <silent> g?   :help fugitive-:Gstatus<CR>
     nnoremap <buffer> <silent> <F1> :help fugitive-:Gstatus<CR>
+    set filetype=fugitive
 
     for [lnum, section] in [[staged_end, 'Staged'], [unstaged_end, 'Unstaged']]
       while len(getline(lnum))


### PR DESCRIPTION
The easiest way for users to define their own maps in Gstatus buffers is
using a ftplugin/fugitive.vim file with a `b:fugitive_type != 'index'`
guard. Setting the filetype after defining the maps allows users to
maniuplate "dangerous" maps and otherwise customize mappings.

For example, in ~/.vim/after/ftplugin/fugitive.vim:

    if !exists('g:loaded_fugitive') || b:fugitive_type != 'index'
        finish
    endif

    " Use s to stage *and* unstage changes: shadows -.
    nmap <buffer> <silent> s -
    xmap <buffer> <silent> s -

    " I hit this by accident.
    nunmap <buffer> X

Alternatively, the buffer settings and maps could be moved to a ftplugin/fugitive_status.vim file (is that how it worked for the old status?).