### PR TITLE
BufRead(Pre|Post), BufNewFile autocmds for files named "index" (#834)

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -271,14 +271,21 @@ augroup fugitive
         \ endif |
         \ let b:undo_ftplugin = get(b:, 'undo_ftplugin', 'exe') . '|setl inex= inc='
 
+  " Handle index files in Git directories, emulating normal sequence of
+  " autocommands if a file named `index` is found elsewhere:
   autocmd BufReadCmd index{,.lock}
         \ if FugitiveIsGitDir(expand('<amatch>:p:h')) |
         \   let b:git_dir = s:Slash(expand('<amatch>:p:h')) |
         \   exe fugitive#BufReadStatus() |
         \ elseif filereadable(expand('<amatch>')) |
+        \   doautocmd BufReadPre |
         \   read <amatch> |
         \   1delete_ |
+        \   doautocmd BufReadPost |
+        \ else |
+        \   doautocmd BufNewFile |
         \ endif
+
   autocmd BufReadCmd    fugitive://*//*             exe fugitive#BufReadCmd()
   autocmd BufWriteCmd   fugitive://*//[0-3]/*       exe fugitive#BufWriteCmd()
   autocmd FileReadCmd   fugitive://*//*             exe fugitive#FileReadCmd()

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -279,7 +279,7 @@ augroup fugitive
         \   exe fugitive#BufReadStatus() |
         \ elseif filereadable(expand('<amatch>')) |
         \   doautocmd BufReadPre |
-        \   read <amatch> |
+        \   keepalt read <amatch> |
         \   1delete_ |
         \   doautocmd BufReadPost |
         \ else |


### PR DESCRIPTION
  - Adds BufReadPre and BufReadPost around read operation if the file is not in a `.git/` and already extant.
  - Adds BufNewFile for new files.

I'm not sure if this covers every corner case, but it solves my original problem and appears to behave as expected with `.git/index` files.

Should fix: https://github.com/tpope/vim-fugitive/issues/834