### PR TITLE
Fix autocmds & alternate file handling for "index"

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -271,14 +271,21 @@ augroup fugitive
         \ endif |
         \ let b:undo_ftplugin = get(b:, 'undo_ftplugin', 'exe') . '|setl inex= inc='
 
+  " Handle index files in Git directories, emulating normal sequence of
+  " autocommands if a file named `index` is found elsewhere:
   autocmd BufReadCmd index{,.lock}
         \ if FugitiveIsGitDir(expand('<amatch>:p:h')) |
         \   let b:git_dir = s:Slash(expand('<amatch>:p:h')) |
         \   exe fugitive#BufReadStatus() |
         \ elseif filereadable(expand('<amatch>')) |
-        \   read <amatch> |
+        \   silent doautocmd BufReadPre |
+        \   keepalt read <amatch> |
         \   1delete_ |
+        \   silent doautocmd BufReadPost |
+        \ else |
+        \   silent doautocmd BufNewFile |
         \ endif
+
   autocmd BufReadCmd    fugitive://*//*             exe fugitive#BufReadCmd()
   autocmd BufWriteCmd   fugitive://*//[0-3]/*       exe fugitive#BufWriteCmd()
   autocmd FileReadCmd   fugitive://*//*             exe fugitive#FileReadCmd()


### PR DESCRIPTION
This commit tweaks the existing autocommand for files matching `index{,.lock}` to:

  - Fire BufReadPre and BufReadPost on either side of the read operation for files not in a `.git/` and already extant.
  - Fire BufNewFile for new files not in a `.git`.
  - Add `keepalt` to the `read`, thus allowing alternative file operations such as Ctrl-^ to work correctly.

Has been tested against:

  - BufReadPost,BufNewFile autocommands
  - A basic test case for alternate files where one is named `index`

Closes https://github.com/tpope/vim-fugitive/issues/834

Closes https://github.com/tpope/vim-fugitive/issues/959