### PR TITLE
Reblame at HEAD from dirty lines

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3868,7 +3868,7 @@ function! s:BlameJump(suffix) abort
   let commit = matchstr(getline('.'),'^\^\=\zs\x\+')
   let suffix = a:suffix
   if commit =~# '^0\+$'
-    let commit = ':0'
+    let commit = 'HEAD'
     let suffix = ''
   endif
   let lnum = matchstr(getline('.'),' \zs\d\+\ze\s\+[([:digit:]]')


### PR DESCRIPTION
HEAD blame seems to be much more useful than index blame. You can continue following evolution of the line with further jumps while before you got struck on 'not yet committed' line if it was already added to the index.