### PR TITLE
Allow --abbrev as :Gblame argument

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3735,7 +3735,7 @@ function! s:Blame(bang, line1, line2, count, mods, args) abort
     if empty(s:Relative('/'))
       call s:throw('file or blob required')
     endif
-    if filter(copy(a:args),'v:val !~# "^\\%(--relative-date\\|--first-parent\\|--root\\|--show-name\\|-\\=\\%([ltfnsew]\\|[MC]\\d*\\)\\+\\)$"') != []
+    if filter(copy(a:args),'v:val !~# "^\\%(--abbrev=\\d*\\|--relative-date\\|--first-parent\\|--root\\|--show-name\\|-\\=\\%([ltfnsew]\\|[MC]\\d*\\)\\+\\)$"') != []
       call s:throw('unsupported option')
     endif
     call map(a:args,'s:sub(v:val,"^\\ze[^-]","-")')

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -186,10 +186,9 @@ that are part of Git repositories).
                                                 *fugitive-:Gblame*
 :Gblame [flags]         Run git-blame on the file and open the results in a
                         scroll bound vertical split.  You can give any of
-                        ltfnsewMC, --relative-date, and --abbrev=N as flags and
-                        they will be passed along to git-blame.  The following
-                        maps, which work on the cursor line commit where
-                        sensible, are provided:
+                        ltfnsewMC as flags and they will be passed along to
+                        git-blame.  The following maps, which work on the
+                        cursor line commit where sensible, are provided:
 
                         g?    show this help
                         A     resize to end of author column

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -186,10 +186,10 @@ that are part of Git repositories).
                                                 *fugitive-:Gblame*
 :Gblame [flags]         Run git-blame on the file and open the results in a
                         scroll bound vertical split.  You can give any of
-                        ltfnsewMC and --relative-date as flags and they will be
-                        passed along to git-blame.  The following maps, which
-                        work on the cursor line commit where sensible, are
-                        provided:
+                        ltfnsewMC, --relative-date, and --abbrev=N as flags and
+                        they will be passed along to git-blame.  The following
+                        maps, which work on the cursor line commit where
+                        sensible, are provided:
 
                         g?    show this help
                         A     resize to end of author column


### PR DESCRIPTION
I'd like to narrow the width of the :Gblame content by showing only 8 characters of the SHA-1 string instead of the default 10. Adding `--abbrev` to the permitted flags lets me do this.