### PR TITLE
Abbreviate commit SHA1s for `:Grebase -i`

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2851,12 +2851,7 @@ function! s:RebaseEdit(cmd, dir) abort
         endif
         let shortened_sha = sha[0:s:sha_length]
         let b:rebase_shas[shortened_sha] = sha
-        let new_rebase_todo[i] = substitute(
-              \ new_rebase_todo[i],
-              \ sha,
-              \ shortened_sha,
-              \ '',
-              \ )
+        let new_rebase_todo[i] = substitute(new_rebase_todo[i], sha, shortened_sha, '')
       endif
     endfor
     call writefile(new_rebase_todo, rebase_todo)

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2844,7 +2844,7 @@ function! s:RebaseEdit(cmd, dir) abort
     let shas = {}
 
     for i in range(len(new))
-      if new[i] =~ '^\l\+\s\+[0-9a-f]\{3,\}\>'
+      if new[i] =~# '^\l\+\s\+[0-9a-f]\{3,\}\>'
         let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
         if !sha_length
           let sha_length = len(s:TreeChomp(a:dir, 'rev-parse', '--short', sha))

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2993,7 +2993,7 @@ function! s:RebaseClean(file) abort
 
     let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
     let rebase_shas = getbufvar(a:file, 'fugitive_rebase_shas')
-    if len(sha) && type(rebase_shas) == v:t_dict && get(rebase_shas, sha)
+    if len(sha) && type(rebase_shas) == type({}) && get(rebase_shas, sha)
       let new[i] = substitute(new[i], sha, rebase_shas[sha], '')
     endif
   endfor

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2840,14 +2840,18 @@ function! s:RebaseEdit(cmd, dir) abort
 
   if filereadable(rebase_todo)
     let new_rebase_todo = readfile(rebase_todo)
+    let s:sha_length = 0
 
     for i in range(len(new_rebase_todo))
       if new_rebase_todo[i] =~ '^[' . join(values(s:rebase_abbrevs), '|') . ']'
         let sha = matchstr(new_rebase_todo[i], '\v[a-f0-9]{5,40}')
+        if !s:sha_length
+          let s:sha_length = len(call('system', ['git rev-parse --short ' . sha]))
+        endif
         let new_rebase_todo[i] = substitute(
               \ new_rebase_todo[i],
               \ sha,
-              \ sha[0:7],
+              \ sha[0:s:sha_length],
               \ '',
               \ )
       endif

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2849,7 +2849,7 @@ function! s:RebaseEdit(cmd, dir) abort
         if !sha_length
           let sha_length = len(s:TreeChomp(a:dir, 'rev-parse', '--short', sha))
         endif
-        let shortened_sha = sha[0:sha_length]
+        let shortened_sha = strpart(sha, 0, sha_length)
         let shas[shortened_sha] = sha
         let new[i] = substitute(new[i], sha, shortened_sha, '')
       endif

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2836,7 +2836,25 @@ let s:rebase_abbrevs = {
       \ }
 
 function! s:RebaseEdit(cmd, dir) abort
-  return a:cmd . ' +setlocal\ bufhidden=wipe ' . s:fnameescape(a:dir . '/rebase-merge/git-rebase-todo')
+  let rebase_todo = s:fnameescape(a:dir . '/rebase-merge/git-rebase-todo')
+
+  if filereadable(rebase_todo)
+    let new_rebase_todo = readfile(rebase_todo)
+
+    for i in range(len(new_rebase_todo))
+      if new_rebase_todo[i] =~ '^[' . join(values(s:rebase_abbrevs), '|') . ']'
+        let sha = matchstr(new_rebase_todo[i], '\v[a-f0-9]{5,40}')
+        let new_rebase_todo[i] = substitute(
+              \ new_rebase_todo[i],
+              \ sha,
+              \ sha[0:7],
+              \ '',
+              \ )
+      endif
+    endfor
+    call writefile(new_rebase_todo, rebase_todo)
+  endif
+  return a:cmd . ' +setlocal\ bufhidden=wipe ' . rebase_todo
 endfunction
 
 function! s:Merge(cmd, bang, mods, args, ...) abort

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2841,7 +2841,7 @@ function! s:RebaseEdit(cmd, dir) abort
   if filereadable(rebase_todo)
     let new_rebase_todo = readfile(rebase_todo)
     let s:sha_length = 0
-    let s:rebase_shas = {}
+    let b:rebase_shas = {}
 
     for i in range(len(new_rebase_todo))
       if new_rebase_todo[i] =~ '^\l\+\s\+[0-9a-f]\{3,\}\>'
@@ -2850,7 +2850,7 @@ function! s:RebaseEdit(cmd, dir) abort
           let s:sha_length = len(call('system', ['git rev-parse --short ' . sha]))
         endif
         let shortened_sha = sha[0:s:sha_length]
-        let s:rebase_shas[shortened_sha] = sha
+        let b:rebase_shas[shortened_sha] = sha
         let new_rebase_todo[i] = substitute(
               \ new_rebase_todo[i],
               \ sha,
@@ -2997,13 +2997,13 @@ function! s:RebaseClean(file) abort
     let new[i] = substitute(new[i], '^\l\>', '\=get(s:rebase_abbrevs,submatch(0),submatch(0))', '')
 
     let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
-    if len(sha) && get(s:rebase_shas, sha)
-      let new[i] = substitute(new[i], sha, s:rebase_shas[sha], '')
+    if len(sha) && get(b:rebase_shas, sha)
+      let new[i] = substitute(new[i], sha, b:rebase_shas[sha], '')
     endif
   endfor
   if new !=# old
     call writefile(new, a:file)
-    unlet s:rebase_shas
+    unlet b:rebase_shas
   endif
   return ''
 endfunction

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2993,7 +2993,7 @@ function! s:RebaseClean(file) abort
 
     let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
     let rebase_shas = getbufvar(a:file, 'fugitive_rebase_shas')
-    if len(sha) && type(rebase_shas) == v:t_dict
+    if len(sha) && type(rebase_shas) == v:t_dict && get(rebase_shas, sha)
       let new[i] = substitute(new[i], sha, rebase_shas[sha], '')
     endif
   endfor

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2993,7 +2993,7 @@ function! s:RebaseClean(file) abort
 
     let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
     let rebase_shas = getbufvar(a:file, 'fugitive_rebase_shas')
-    if len(sha) && type(rebase_shas) == type({}) && get(rebase_shas, sha)
+    if len(sha) && type(rebase_shas) == type({}) && has_key(rebase_shas, sha)
       let new[i] = substitute(new[i], sha, rebase_shas[sha], '')
     endif
   endfor

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2847,7 +2847,7 @@ function! s:RebaseEdit(cmd, dir) abort
       if new[i] =~ '^\l\+\s\+[0-9a-f]\{3,\}\>'
         let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
         if !sha_length
-          let sha_length = len(call('system', ['git rev-parse --short ' . sha]))
+          let sha_length = len(s:TreeChomp(a:dir, 'rev-parse', '--short', sha))
         endif
         let shortened_sha = sha[0:sha_length]
         let shas[shortened_sha] = sha

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2999,7 +2999,6 @@ function! s:RebaseClean(file) abort
   endfor
   if new !=# old
     call writefile(new, a:file)
-    unlet b:fugitive_rebase_shas
   endif
   return ''
 endfunction

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2992,8 +2992,9 @@ function! s:RebaseClean(file) abort
     let new[i] = substitute(new[i], '^\l\>', '\=get(s:rebase_abbrevs,submatch(0),submatch(0))', '')
 
     let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
-    if len(sha) && get(b:fugitive_rebase_shas, sha)
-      let new[i] = substitute(new[i], sha, b:fugitive_rebase_shas[sha], '')
+    let rebase_shas = getbufvar(a:file, 'fugitive_rebase_shas', {})
+    if len(sha) && get(rebase_shas, sha)
+      let new[i] = substitute(new[i], sha, rebase_shas[sha], '')
     endif
   endfor
   if new !=# old

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2839,22 +2839,22 @@ function! s:RebaseEdit(cmd, dir) abort
   let rebase_todo = s:fnameescape(a:dir . '/rebase-merge/git-rebase-todo')
 
   if filereadable(rebase_todo)
-    let new_rebase_todo = readfile(rebase_todo)
+    let new = readfile(rebase_todo)
     let s:sha_length = 0
     let b:rebase_shas = {}
 
-    for i in range(len(new_rebase_todo))
-      if new_rebase_todo[i] =~ '^\l\+\s\+[0-9a-f]\{3,\}\>'
-        let sha = matchstr(new_rebase_todo[i], '\v[a-f0-9]{5,40}')
+    for i in range(len(new))
+      if new[i] =~ '^\l\+\s\+[0-9a-f]\{3,\}\>'
+        let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
         if !s:sha_length
           let s:sha_length = len(call('system', ['git rev-parse --short ' . sha]))
         endif
         let shortened_sha = sha[0:s:sha_length]
         let b:rebase_shas[shortened_sha] = sha
-        let new_rebase_todo[i] = substitute(new_rebase_todo[i], sha, shortened_sha, '')
+        let new[i] = substitute(new[i], sha, shortened_sha, '')
       endif
     endfor
-    call writefile(new_rebase_todo, rebase_todo)
+    call writefile(new, rebase_todo)
   endif
   return a:cmd . ' +setlocal\ bufhidden=wipe ' . rebase_todo
 endfunction

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2843,7 +2843,7 @@ function! s:RebaseEdit(cmd, dir) abort
     let s:sha_length = 0
 
     for i in range(len(new_rebase_todo))
-      if new_rebase_todo[i] =~ '^[' . join(values(s:rebase_abbrevs), '|') . ']'
+      if new_rebase_todo[i] =~ '^\l\+\s\+[0-9a-f]\{3,\}\>'
         let sha = matchstr(new_rebase_todo[i], '\v[a-f0-9]{5,40}')
         if !s:sha_length
           let s:sha_length = len(call('system', ['git rev-parse --short ' . sha]))

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2845,7 +2845,7 @@ function! s:RebaseEdit(cmd, dir) abort
 
     for i in range(len(new))
       if new[i] =~# '^\l\+\s\+[0-9a-f]\{3,\}\>'
-        let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
+        let sha = matchstr(new[i], '\C\v[a-f0-9]{5,40}')
         if !sha_length
           let sha_length = len(s:TreeChomp(a:dir, 'rev-parse', '--short', sha))
         endif
@@ -2991,7 +2991,7 @@ function! s:RebaseClean(file) abort
   for i in range(len(new))
     let new[i] = substitute(new[i], '^\l\>', '\=get(s:rebase_abbrevs,submatch(0),submatch(0))', '')
 
-    let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
+    let sha = matchstr(new[i], '\C\v[a-f0-9]{5,40}')
     let rebase_shas = getbufvar(a:file, 'fugitive_rebase_shas')
     if len(sha) && type(rebase_shas) == type({}) && has_key(rebase_shas, sha)
       let new[i] = substitute(new[i], sha, rebase_shas[sha], '')

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2992,8 +2992,8 @@ function! s:RebaseClean(file) abort
     let new[i] = substitute(new[i], '^\l\>', '\=get(s:rebase_abbrevs,submatch(0),submatch(0))', '')
 
     let sha = matchstr(new[i], '\v[a-f0-9]{5,40}')
-    let rebase_shas = getbufvar(a:file, 'fugitive_rebase_shas', {})
-    if len(sha) && get(rebase_shas, sha)
+    let rebase_shas = getbufvar(a:file, 'fugitive_rebase_shas')
+    if len(sha) && type(rebase_shas) == v:t_dict
       let new[i] = substitute(new[i], sha, rebase_shas[sha], '')
     endif
   endfor


### PR DESCRIPTION
Rather than generating the full 40 character SHA1, this PR changes
the rebase todo file to use the abbreviated kind.