### PR TITLE
Fix issues when git-dir is a symlink

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -308,7 +308,17 @@ function! fugitive#Prepare(...) abort
   call s:PreparePathArgs(cmd, dir, !exists('explicit_pathspec_option'))
   let args = join(map(copy(cmd), 's:shellesc(v:val)'))
   if empty(tree) || index(cmd, '--') == len(cmd) - 1
-    let args = s:shellesc('--git-dir=' . dir) . ' ' . args
+    let git_dir = s:shellesc('--git-dir=' . dir)
+    if exists('g:git_dir_links')
+      for d in keys(g:git_dir_links)
+        if d == dir
+          let worktree_for_git_link = substitute(g:git_dir_links[d], '\.git$', '', '')
+          let git_dir = git_dir . ' ' . s:shellesc('--work-tree=' . worktree_for_git_link)
+          break
+        endif
+      endfor
+    endif
+    let args = git_dir . ' ' . args
   elseif fugitive#GitVersion(1, 9)
     let args = '-C ' . s:shellesc(tree) . ' ' . args
   else

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -181,7 +181,11 @@ function! FugitiveExtractGitDir(path) abort
     if type ==# 'dir' && FugitiveIsGitDir(dir)
       return dir
     elseif type ==# 'link' && FugitiveIsGitDir(dir)
-      return resolve(dir)
+      if !exists('g:git_dir_links')
+        let g:git_dir_links = {}
+      endif
+      let g:git_dir_links[resolve(dir)] = dir
+      return dir
     elseif type !=# '' && filereadable(dir)
       let line = get(readfile(dir, '', 1), 0, '')
       if line =~# '^gitdir: \.' && FugitiveIsGitDir(root.'/'.line[8:-1])
@@ -276,6 +280,9 @@ augroup fugitive
         \ if FugitiveIsGitDir(expand('<amatch>:p:h')) |
         \   let b:git_dir = s:Slash(expand('<amatch>:p:h')) |
         \   exe fugitive#BufReadStatus() |
+        \   if exists('g:git_dir_links') && has_key(g:git_dir_links, b:git_dir) |
+        \     let b:git_dir = g:git_dir_links[b:git_dir] |
+        \   endif |
         \ elseif filereadable(expand('<amatch>')) |
         \   silent doautocmd BufReadPre |
         \   keepalt read <amatch> |


### PR DESCRIPTION
Test steps:

1. open a file in a repo whose .git is a symbol link, make some modification on the file.
1. run `:Gvdiff` in vim, which should show correct diff.
1. run `:Gstatus` in vim, which should list current file under `Unstaged`.
1. in the `FUGITIVE` buffer for `Gstatus`, go to line of current file, press `dv`, which should show correct diff.
