### PR TITLE
s:BuildShell: fix E706

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -342,8 +342,7 @@ function! s:BuildShell(dir, env, args) abort
   else
     let pre = 'cd ' . s:shellesc(tree) . (s:winshell() ? '& ' : '; ') . pre
   endif
-  let cmd = join(map(cmd, 's:shellesc(v:val)'))
-  return pre . g:fugitive_git_executable . ' ' . cmd
+  return pre . g:fugitive_git_executable . ' ' . join(map(cmd, 's:shellesc(v:val)'))
 endfunction
 
 function! fugitive#Prepare(...) abort


### PR DESCRIPTION
This happens with old Vim versions (before 7.4.1546):

> Vim(let):E706: Variable type mismatch for: cmd

Ref: https://github.com/vim/vim/commit/f6f32c38b

Not sure if you want to take this, but could not find a minimal required Vim version.
I've noticed this with Neomake's test suite, where integration with vim-fugitive is tested.