### PR TITLE
Vim's `redraw` can change v:shell_error

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -4782,9 +4782,10 @@ function! s:BlameSubcommand(line1, count, range, bang, mods, args) abort
     else
       silent! execute '%write !'.basecmd.' > '.temp.' 2> '.error
     endif
+    let l:shell_error = v:shell_error
     redraw
     try
-      if v:shell_error
+      if l:shell_error
         let lines = readfile(error)
         if empty(lines)
           let lines = readfile(temp)


### PR DESCRIPTION
If any other plugins besides `vim-fugitive` are present in user's instance of Vim, they can call external programs to show some properties. Redraw will force them to call this programs again and value
of last shell error can be changed.

Example of such plugins is [vim-airline](https://github.com/vim-airline/vim-airline).

The issue was introduced in 4daa0c5.