### PR TITLE
Fix reverse blame jump for the boundary edge case

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -4750,7 +4750,7 @@ function! s:BlameCommitFileLnum(...) abort
   let commit = matchstr(line, '^\^\=\zs\x\+')
   if commit =~# '^0\+$'
     let commit = ''
-  elseif line !~# '^\^' && has_key(state, 'blame_reverse_end')
+  elseif has_key(state, 'blame_reverse_end')
     let commit = get(s:LinesError('rev-list', '--ancestry-path', '--reverse', commit . '..' . state.blame_reverse_end)[0], 0, '')
   endif
   let lnum = +matchstr(line, ' \zs\d\+\ze \%((\| *\d\+)\)')


### PR DESCRIPTION
When the line is reverse-blamed to an *immediate* child of the current
commit it is shown as `^commit` in the reverse blame output. In this
case we still need to open the child of this commit since it will be a
commit removing the line.

Closes https://github.com/tpope/vim-fugitive/issues/1359