### PR TITLE
Fix script number in s:function()

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -15,7 +15,7 @@ endif
 " Section: Utility
 
 function! s:function(name) abort
-  return function(substitute(a:name,'^s:',matchstr(expand('<sfile>'), '<SNR>\d\+_'),''))
+  return function(substitute(a:name,'^s:',matchstr(expand('<sfile>'), '<SNR>\d\+_\zefunction'),''))
 endfunction
 
 function! s:sub(str,pat,rep) abort


### PR DESCRIPTION
**Problem:**

Assume the following code in your vimrc:

    nnoremap <leader>n :call <sid>foo()<cr>

    function! s:foo()
      Gllog
    endfunction

Using that mapping would result in `E700: Unknown function: <SNR>1_LogParse`.

**What happens:**

The `expand('<sfile>')` in `s:function()` evaluates to:

    <SNR>1_foo[1]..fugitive#LogCommand[74]..<SNR>68_function

Then the `matchstr()` would extract the wrong `<SNR>1_` (vimrc) instead of the
correct `<SNR>68_` (autoload/fugitive.vim).

**Solution:**

Adjust the regexp to extract the script number of the last function in the call
chain, `s:function()` itself, which is guaranteed to be in the correct script,
autoload/fugitive.vim.

**Alternative solution:**

I'm not 100% sure, why `s:function()` is actually needed (legacy reasons?), but changing [this line](https://github.com/tpope/vim-fugitive/blob/master/autoload/fugitive.vim#L3982) to either `s:function('<sid>LogParse')` or `function('s:LogParse')` would work just as well.