### PR TITLE
Fix incorrect script id from nested function call #2

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -15,7 +15,7 @@ endif
 " Section: Utility
 
 function! s:function(name) abort
-  return function(substitute(a:name,'^s:',matchstr(expand('<sfile>'), '.*<SNR>\d\+_'),''))
+  return function(substitute(a:name,'^s:',matchstr(expand('<sfile>'), '.*\zs<SNR>\d\+_'),''))
 endfunction
 
 function! s:sub(str,pat,rep) abort


### PR DESCRIPTION
This is a follow-up to 28abadc.

Without the `\zs`, everything up to the regexp for the script ID would be used, resulting in errors like this:

    Error detected while processing function <SNR>67_add_methods[2]..<SNR>67_function:
    line    1:
    E475: Invalid argument: function <SNR>67_add_methods[2]..<SNR>67_repo_dir
    E475: Invalid argument: function <SNR>67_add_methods[2]..<SNR>67_repo_prepare
    E475: Invalid argument: function <SNR>67_add_methods[2]..<SNR>67_repo_superglob
    E475: Invalid argument: function <SNR>67_add_methods[2]..<SNR>67_repo_config
    E475: Invalid argument: function <SNR>67_add_methods[2]..<SNR>67_buffer_repo

Now, `s:function()` is the same as the one used in scriptease.