### PR TITLE
Add built-in package management installation way to the README 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,13 +69,12 @@ For more information, see `:help fugitive`.
 
 ## Installation
 
-If you don't have a preferred installation method, one option is to install
-[pathogen.vim](https://github.com/tpope/vim-pathogen), and then copy
-and paste:
-
-    cd ~/.vim/bundle
-    git clone https://github.com/tpope/vim-fugitive.git
-    vim -u NONE -c "helptags vim-fugitive/doc" -c q
+Install using your favorite package manager, or use Vim's built-in package support:
+	
+    mkdir -p ~/.vim/pack/tpope/start
+    cd ~/.vim/pack/tpope/start
+    git clone https://tpope.io/vim/fugitive.git
+    vim -u NONE -c "helptags fugitive/doc" -c q
 
 ## FAQ
 


### PR DESCRIPTION
Dear @tpope 
I am a new user in vim then I found your awesome plugins for that and I really appreciate your efforts 
The only problem was about installing them inside the new version which I knew we don't have to use an external package manager, therefore, I just added the missing part in order to make it easier to install for the people like myself :)