### PR TITLE
Add fixup/squash keybindings when at blame window

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5240,6 +5240,9 @@ function! s:BlameFileType() abort
   call s:Map('n', 'o',    ':<C-U>exe <SID>BlameCommit("split")<CR>', '<silent>')
   call s:Map('n', 'O',    ':<C-U>exe <SID>BlameCommit("tabedit")<CR>', '<silent>')
   call s:Map('n', 'p',    ':<C-U>exe <SID>BlameCommit("pedit")<CR>', '<silent>')
+  call s:Map('n', 'cf',   ':<C-U>Gcommit --fixup=<C-R>=<SID>SquashArgument()<CR>', '')
+  call s:Map('n', 'cs',   ':<C-U>Gcommit --squash=<C-R>=<SID>SquashArgument()<CR>', '')
+  call s:Map('n', 'cA',   ':<C-U>Gcommit --edit --squash=<C-R>=<SID>SquashArgument()<CR>', '')
 endfunction
 
 augroup fugitive_blame

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -89,6 +89,12 @@ that are part of Git repositories).
                         -     reblame at commit
                         ~     reblame at [count]th first grandparent
                         P     reblame at [count]th parent (like HEAD^[count])
+                        cf    create a `fixup!` commit for the commit under
+                              the cursor
+                        cs    create a `squash!` commit for the commit under
+                              the cursor
+                        cA    create a `squash!` commit for the commit under
+                              the cursor and edit the message.
 
 :[range]Gblame [flags]  If a range is given, just that part of the file will
 :Gblame [flags] {file}  be blamed, and a horizontal split without


### PR DESCRIPTION
This allows you to use the the keybinding `cf`, `cs`, `cA` to create a fixup/squash commits for the selected line in `:Gblame` window, with similar semantic to `:Gstatus` window. 

I find this very useful because a lot of the time the lines around the lines you are fixing up often were modified in the commit that you want to update.