### PR TITLE
Disable signcolumn during Gblame

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5008,7 +5008,7 @@ function! s:BlameSubcommand(line1, count, range, bang, mods, args) abort
         if exists('+cursorbind')
           setlocal cursorbind
         endif
-        setlocal nonumber scrollbind nowrap foldcolumn=0 nofoldenable winfixwidth
+        setlocal nonumber scrollbind nowrap foldcolumn=0 nofoldenable winfixwidth signcolumn=no
         if exists('+relativenumber')
           setlocal norelativenumber
         endif

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5008,9 +5008,12 @@ function! s:BlameSubcommand(line1, count, range, bang, mods, args) abort
         if exists('+cursorbind')
           setlocal cursorbind
         endif
-        setlocal nonumber scrollbind nowrap foldcolumn=0 nofoldenable winfixwidth signcolumn=no
+        setlocal nonumber scrollbind nowrap foldcolumn=0 nofoldenable winfixwidth
         if exists('+relativenumber')
           setlocal norelativenumber
+        endif
+        if exists('+signcolumn')
+          setlocal signcolumn=no
         endif
         execute "vertical resize ".(s:linechars('.\{-\}\ze\s\+\d\+)')+1)
         call s:Map('n', 'A', ":<C-u>exe 'vertical resize '.(<SID>linechars('.\\{-\\}\\ze [0-9:/+-][0-9:/+ -]* \\d\\+)')+1+v:count)<CR>", '<silent>')


### PR DESCRIPTION
Myself and a few coworkers use Ale for linting in vim, when the gutter is enabled `signcolumn=yes`, there is spacing on the left of Gblame which causes text to get cut off on the right side of the pane.

![Screen Shot 2019-10-17 at 9 50 04 AM](https://user-images.githubusercontent.com/6757931/67026628-6974da00-f0c5-11e9-8e89-1f9a0b51d816.png)

Simply added to the setlocal options during Gblame pane creation to disable signcolumn for any other people that may have that enabled for other plugins.