### PR TITLE
Reset scrollbind/cursorbind after reblaming

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5109,12 +5109,10 @@ function! s:BlameJump(suffix, ...) abort
     let winnr = bufwinnr(blame_bufnr)
     if winnr > 0
       exe winnr.'wincmd w'
+      exe bufnr.'bdelete'
     endif
     execute 'Gedit' s:fnameescape(commit . suffix . ':' . path)
     execute lnum
-    if winnr > 0
-      exe bufnr.'bdelete'
-    endif
   endif
   if exists(':Gblame')
     let my_bufnr = bufnr('')


### PR DESCRIPTION
Hello, I've been hitting a bug where my buffers will sometimes end up with scrollbind/cursorbind after exiting Gblame. I finally narrowed it down to happening when I do a reblame (e.g., with ~) and figured out the root cause. See the commit message for details. Let me know if this is the proper way to fix this issue.