### PR TITLE
Fix slow scroll and updates

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5913,17 +5913,21 @@ endfunction
 " Section: Statusline
 
 function! fugitive#Statusline(...) abort
+  if exists("w:update") && reltimefloat(reltime(w:update))<10
+      return w:status
+  endif
   let dir = s:Dir(bufnr(''))
   if empty(dir)
     return ''
   endif
-  let status = ''
+  let w:status = ''
   let commit = s:DirCommitFile(@%)[1]
   if len(commit)
-    let status .= ':' . commit[0:6]
+    let w:status .= ':' . commit[0:6]
   endif
-  let status .= '('.FugitiveHead(7, dir).')'
-  return '[Git'.status.']'
+  let w:status .= '('.FugitiveHead(7, dir).')'
+  let w:update = reltime()
+  return '[Git'.w:status.']'
 endfunction
 
 function! fugitive#statusline(...) abort


### PR DESCRIPTION
Hi,

Every time I worked using remote filesystems I found vim slow or veeery slow. Today I realized this was caused by my fugitive status line. So I decided to add some cache. It's short, only 10 seconds, but it makes a huuuge difference! Scrolling is now butter smooth again and vim is much snappier in general.

Please critique if I made some stupid mistakes or merge if you like it.