### PR TITLE
fugitive://foo should not to be left instead of edited buffer

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -4095,6 +4095,12 @@ function! s:OpenParse(args, wants_cmd) abort
 endfunction
 
 function! s:DiffClose() abort
+  for bufnr in tabpagebuflist()
+    if bufname(bufnr) =~# '^fugitive://'
+      execute bufwinnr(bufnr) .'windo quit'
+    endif
+  endfor
+
   let mywinnr = winnr()
   for winnr in [winnr('#')] + range(winnr('$'),1,-1)
     if winnr != mywinnr && getwinvar(winnr,'&diff')


### PR DESCRIPTION
Any problem with this small addition?

The reason to use :windo instead of :bufdo is that the latter sometimes fails to :quit fugitive://foo, especially diff-buffers are in horizontal.