### PR TITLE
Use jobs in lieu of `:!` for :Git

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -317,7 +317,7 @@ P                       under the cursor. On untracked files, this instead
                                                 *fugitive_d*
 Diff maps ~
                                                 *fugitive_dp*
-dp                      Invoke |:Git!| diff on the file under the cursor.
+dp                      Invoke |:Git| diff on the file under the cursor.
                         Deprecated in favor of inline diffs.
 
                                                 *fugitive_dd*

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -16,12 +16,15 @@ These commands are local to the buffers in which they work (generally, buffers
 that are part of Git repositories).
 
                                                 *:Git* *fugitive-:G*
-:Git {args}             Run an arbitrary git command. Similar to :!git [args]
-:G {args}               but chdir to the repository tree first.  For some
-                        subcommands, a Fugitive command is called instead.
+:Git {args}             Run an arbitrary git command and display any output.
+:G {args}               Any file the command edits (for example, a commit
+                        message) will be loaded into a split window.  Closing
+                        that window will resume running the command.  A few
+                        commands have different behavior; these are documented
+                        below.
 
-:Git! {args}            Like |:Git|, but capture the output into a temp file,
-:Git --paginate {args}  and |:split| that temp file.  Use :0Git to
+:Git! {args}            Run an arbitrary git command, capture output to a temp
+:Git --paginate {args}  file, and |:split| that temp file.  Use :0Git to
 :Git -p {args}          |:edit| the temp file instead.  A temp file is always
                         used for diff and log commands.
 

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -45,22 +45,6 @@ that are part of Git repositories).
 :Git revert [args]      A wrapper around git-revert.  Similar to |:Gcommit|.
 :Grevert [args]
 
-                                                *:Git-merge* *:Gmerge*
-:Git merge [args]       Calls git-merge and loads errors and conflicted files
-:Gmerge [args]          into the |quickfix| list.  Opens a |:Gcommit| style
-                        split window for the commit message if the merge
-                        succeeds.  If called during a merge conflict, the
-                        conflicted files from the current index are loaded
-                        into the |quickfix| list.
-
-                                                *:Git-pull* *:Gpull*
-:Git pull [args]        Like |:Gmerge|, but for git-pull.
-:Gpull [args]
-
-                                                *:Git-rebase* *:Grebase*
-:Git rebase [args]      Like |:Gmerge|, but for git-rebase.  Interactive
-:Grebase [args]         rebase is experimentally supported.
-
                                                 *:Git-push* *:Gpush*
 :Git push [args]        Invoke git-push, load the results into the |quickfix|
 :Gpush [args]           list, and invoke |:cwindow| to reveal any errors.
@@ -118,6 +102,17 @@ that are part of Git repositories).
 
                                                 *:Git-mergetool*
 :Git mergetool [args]   Like |:Git-difftool|, but target merge conflicts.
+
+                                                *:Git-merge* *:Gmerge*
+:Gmerge [args]          Deprecated alias for |:Git| merge. Use |:Git-mergetool|
+                        to get the old behavior of loading merge conflicts
+                        into the quickfix list.
+
+                                                *:Git-pull* *:Gpull*
+:Gpull [args]           Deprecated alias for |:Git| pull.
+
+                                                *:Git-rebase* *:Grebase*
+:Grebase [args]         Deprecated alias for |:Git| rebase.
 
                                                  *:Gclog* *:Glog*
 :Gclog[!] [args]        Use git-log [args] to load the commit history into the

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -17,11 +17,13 @@ that are part of Git repositories).
 
                                                 *:Git* *fugitive-:G*
 :Git {args}             Run an arbitrary git command and display any output.
-:G {args}               Any file the command edits (for example, a commit
-                        message) will be loaded into a split window.  Closing
-                        that window will resume running the command.  A few
-                        commands have different behavior; these are documented
-                        below.
+:G {args}               On UNIX this uses a pty and on other platforms it uses
+                        a pipe, which will cause some behavior differences
+                        such as the absence of progress bars.  Any file the
+                        command edits (for example, a commit message) will be
+                        loaded into a split window.  Closing that window will
+                        resume running the command.  A few Git subcommands
+                        have different behavior; these are documented below.
 
 :Git! {args}            Run an arbitrary git command, capture output to a temp
 :Git --paginate {args}  file, and |:split| that temp file.  Use :0Git to
@@ -32,28 +34,6 @@ that are part of Git repositories).
 :Git                    Bring up a summary window vaguely akin to git-status.
 :G                      Press g? or see |fugitive-maps| for usage.
 :Gstatus
-
-                                                *:Git-commit* *:Gcommit*
-:Git commit [args]      A wrapper around git-commit.  Unless the arguments
-:Gcommit [args]         given would skip the invocation of an editor (e.g.,
-                        -m), a split window will be used to obtain a commit
-                        message, or a new tab if -v is given.  Write and close
-                        the window (:wq) to finish the commit. To cancel, use
-                        an empty message.
-
-                                                *:Git-revert* *:Grevert*
-:Git revert [args]      A wrapper around git-revert.  Similar to |:Gcommit|.
-:Grevert [args]
-
-                                                *:Git-push* *:Gpush*
-:Git push [args]        Invoke git-push, load the results into the |quickfix|
-:Gpush [args]           list, and invoke |:cwindow| to reveal any errors.
-                        |:Dispatch| is used if available for asynchronous
-                        invocation.
-
-                                                *:Git-fetch* *:Gfetch*
-:Git fetch [args]       Like |:Gpush|, but for git-fetch.
-:Gfetch [args]
 
                                                 *:Git-blame* *:Gblame*
 :Git blame [flags]      Run git-blame [flags] on the current file and open the
@@ -103,6 +83,16 @@ that are part of Git repositories).
                                                 *:Git-mergetool*
 :Git mergetool [args]   Like |:Git-difftool|, but target merge conflicts.
 
+                                                *:Git-push* *:Gpush*
+:Git push [args]        Invoke git-push, load the results into the |quickfix|
+:Gpush [args]           list, and invoke |:cwindow| to reveal any errors.
+                        |:Dispatch| is used if available for asynchronous
+                        invocation.
+
+                                                *:Git-fetch* *:Gfetch*
+:Git fetch [args]       Like |:Gpush|, but for git-fetch.
+:Gfetch [args]
+
                                                 *:Git-merge* *:Gmerge*
 :Gmerge [args]          Deprecated alias for |:Git| merge. Use |:Git-mergetool|
                         to get the old behavior of loading merge conflicts
@@ -113,6 +103,12 @@ that are part of Git repositories).
 
                                                 *:Git-rebase* *:Grebase*
 :Grebase [args]         Deprecated alias for |:Git| rebase.
+
+                                                *:Git-commit* *:Gcommit*
+:Gcommit [args]         Deprecated alias for |:Git| commit.
+
+                                                *:Git-revert* *:Grevert*
+:Grevert [args]         Deprecated alias for |:Git| revert.
 
                                                  *:Gclog* *:Glog*
 :Gclog[!] [args]        Use git-log [args] to load the commit history into the


### PR DESCRIPTION
This solves several problems, big and small, with using `:!`:

* Inconsistent behavior across platforms.  `:!` uses the current terminal in
  terminal Vim, a dumb pseudo-TTY in GVim, and a pipe in Neovim.
* If Git needs a text editor, it spawns it as a child process, which is an
  unsatisfying experience using terminal Vim and broken on GVim and Neovim.
  This has necessitated the creation of command wrappers like `:Gcommit` and
  `:Grebase`, and these wrappers are imperfect, leaky abstractions.  Many
  commands, such as `git tag`, need wrappers but lack them.
* The pager experience is similarly flawed.  We currently work around this
  with `--no-pager` on GVim and Neovim, and by intercepting particularly
  chatty commands like `git log` and loading them into a temp buffer instead.
* Neovim's use of a pipe makes it impossible for commands like `git push` to
  ask for a password.  Earlier versions would hard lock if a command attempted
  to do so.
* A press enter prompt is always issued, even for low ceremony commands like
  `:Git add %`.  This not only directly inconveniences the user, but also
  prevents the use of `:Git` in anywhere in Fugitive's internals that we don't
  want a prompt, such as the `s`, `u`, and `-` maps in `:Gstatus`.

This pull request uses Vim 8's `job_start()` and Neovim's `jobstart()` for the
default `:Git` executor.  The `pty` flag is passed to get better handling of
passwords, among other things, and `TERM` is forced to `dumb` to disable ANSI
escape sequences.  I have no plans to support ANSI colors, but I'll entertain
optionally using an external library to implement them if one is available.

Fugitive has been updated to take advantage of the new job executor in the
following ways:

* Custom `:Grebase`, `:Gmerge`, and `:Gpull` implementations completely
  removed.  Using them on Vim 7 will fall back to `:!`, which seems good
  enough for the outdated server use case.  This drops the old behavior of
  loading the output into the quickfix list, which I always found to be more
  annoying than helpful.  For loading conflicts into the quickfix list, use
  the new native `:Git mergetool`.
* `:Gcommit` and `:Grevert` use the job executor if available, and fall back
  to the custom implementation if not.  (I'll probably end up ripping out this
  custom implementation as well.)  This means the old "`:Gcommit -v` in new
  tab" behavior is gone.  It could be brought back, but since it's also
  available on `:tab Gcommit -v`, I've moved it to the `cv` maps instead.
* `:Gpush` and `:Gfetch` now only use their `:make`/`:Make` based quickfix
  capture if a bang (`!`) is passed.  This probably won't make it into the
  release, but it will enable people to test that password input is working as
  expected.

**I need people to test the `job` branch**, especially users of Neovim and
*especially* users of Windows.  Please comment with any issues.  Long
term testing is especially helpful; I want to see what corner cases pop up.
I aim to merge this after the next Fugitive release, hopefully within a month
or two.