### PR TITLE
Fix typo --include-index to --keep-index in help

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -502,7 +502,7 @@ czz                     Push stash.  Pass a [count] of 1 to add
                         `--include-untracked` or 2 to add `--all`.
 
 czw                     Push stash of worktree.  Like `czz` with
-                        `--include-index`.
+                        `--keep-index`.
 
 czA                     Apply topmost stash, or stash@{count}.
 


### PR DESCRIPTION
https://github.com/tpope/vim-fugitive/blob/0e6f72b005312225ffb47290500941d59eb1f0f7/autoload/fugitive.vim#L5858