### PR TITLE
Fix stash map

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -6026,7 +6026,7 @@ function! fugitive#MapJumps(...) abort
     call s:Map('n', 'czP', ':<C-U>Git stash pop --quiet stash@{<C-R>=v:count<CR>}<CR>')
     call s:Map('n', 'czv', ':<C-U>exe "Gedit" fugitive#RevParse("stash@{" . v:count . "}")<CR>', '<silent>')
     call s:Map('n', 'czw', ':<C-U>Git stash --keep-index<C-R>=v:count > 1 ? " --all" : v:count ? " --include-untracked" : ""<CR><CR>')
-    call s:Map('n', 'czz', ':<C-U>Git stash <C-R>=v:count > 1 ? " --all" : v:count ? " --include-untracked" : ""<CR>')
+    call s:Map('n', 'czz', ':<C-U>Git stash <C-R>=v:count > 1 ? " --all" : v:count ? " --include-untracked" : ""<CR><CR>')
     call s:Map('n', 'cz?', ':<C-U>help fugitive_cz<CR>', '<silent>')
 
     call s:Map('n', 'co<Space>', ':Git checkout<Space>')


### PR DESCRIPTION
`czz` used to act without confirmation before. But
6b40e510080e25f9141170f629f5a3576d57e042 changed it to require `<CR>`.
Given that `czw` keeps working without confirmation and that there
is a separate `cz<Space>` map - seems like the change was not intended?