### PR TITLE
Add ftplugin for fugitive filetype

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2699,8 +2699,7 @@ function! s:StatusCommand(line1, line2, range, count, bang, mods, reg, arg, args
   try
     let mods = s:Mods(a:mods, &splitbelow ? 'botright' : 'topleft')
     let file = fugitive#Find(':', dir)
-    let arg = ' +setl\ foldmethod=syntax\ foldlevel=1\|let\ w:fugitive_status=FugitiveGitDir() ' .
-          \ s:fnameescape(file)
+    let arg = s:fnameescape(file)
     for winnr in range(1, winnr('$'))
       if s:cpath(file, fnamemodify(bufname(winbufnr(winnr)), ':p'))
         if winnr == winnr()

--- a/ftplugin/fugitive.vim
+++ b/ftplugin/fugitive.vim
@@ -1,0 +1,7 @@
+if exists('b:did_ftplugin') || &filetype !=# 'fugitive'
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl foldmethod=syntax foldlevel=1
+let w:fugitive_status=FugitiveGitDir()


### PR DESCRIPTION
Allows users to override foldlevel as they can autocmd on FileType.

See #1563

Right now foldlevel is unconditionally set to 1 after reading the file.

An autocmd on BufWinEnter does not work either.