### PR TITLE
Fix doc. Mark `C` mapping as deprecated in the user documentation

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -344,6 +344,7 @@ P                       Open the current file in the [count]th parent.
 
                                                 *fugitive_C*
 C                       Open the commit containing the current file.
+                        Deprecated in favor of cc.
 
                                                 *fugitive_CTRL-P* *fugitive_(*
 (                       Jump to the previous file, hunk, or revision.


### PR DESCRIPTION
Since `C` mapping has been deprecated and there is an error message on
its usage, the user documentation should have a note about it.