### PR TITLE
Add command Gdiffoff that calls diffoff and closes buffers

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -4503,6 +4503,11 @@ function! s:DiffClose() abort
   diffoff!
 endfunction
 
+function! fugitive#DiffClose2() abort
+  call s:DiffClose()
+endfunction
+
+
 function! s:BlurStatus() abort
   if (&previewwindow || exists('w:fugitive_status')) && get(b:,'fugitive_type', '') ==# 'index'
     let winnrs = filter([winnr('#')] + range(1, winnr('$')), 's:UsableWin(v:val)')

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -462,6 +462,8 @@ exe 'command! -bar -bang -nargs=* -range=-1                -complete=customlist,
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gdiffsplit  exe fugitive#Diffsplit(1, <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Ghdiffsplit exe fugitive#Diffsplit(0, <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gvdiffsplit exe fugitive#Diffsplit(0, <bang>0, "vert <mods>", <q-args>, [<f-args>])'
+exe 'command! Gdiffoff  exe fugitive#DiffClose2()'
+
 
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gw     exe fugitive#WriteCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gwrite exe fugitive#WriteCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'


### PR DESCRIPTION
Sometimes when you call Gdiff on a cpp file and afterwards you call Gdiff (maybe by mistake) on a different file then both diffs are mixed and the visualization is not useful.  

In this situation Gdiffoff lets the user reset the tab