### PR TITLE
Fix jumps from blame commits with ignore marks

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5187,7 +5187,7 @@ endfunction
 function! s:BlameCommitFileLnum(...) abort
   let line = a:0 ? a:1 : getline('.')
   let state = a:0 ? a:2 : s:TempState()
-  let commit = matchstr(line, '^\^\=\zs\x\+')
+  let commit = matchstr(line, '^\^\=[?*]*\zs\x\+')
   if commit =~# '^0\+$'
     let commit = ''
   elseif has_key(state, 'blame_reverse_end')


### PR DESCRIPTION
c212d854d5c872f43e0a3f064241b086d07fbb6f added initial support for
marks added by blame.markIgnoredLines and blame.markUnblamableLines.

One more change is needed to parse the blame line properly to enable
jumps.