### PR TITLE
Restore correct cursor position in commit buffer

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2159,13 +2159,13 @@ function! fugitive#BufReadCmd(...) abort
           keepjumps 1
           keepjumps call search('^parent ')
           if getline('.') ==# 'parent '
-            silent keepjumps delete_
+            silent lockmarks keepjumps delete_
           else
             silent exe (exists(':keeppatterns') ? 'keeppatterns' : '') 'keepjumps s/\m\C\%(^parent\)\@<! /\rparent /e' . (&gdefault ? '' : 'g')
           endif
           keepjumps let lnum = search('^encoding \%(<unknown>\)\=$','W',line('.')+3)
           if lnum
-            silent keepjumps delete_
+            silent lockmarks keepjumps delete_
           end
           silent exe (exists(':keeppatterns') ? 'keeppatterns' : '') 'keepjumps 1,/^diff --git\|\%$/s/\r$//e'
           keepjumps 1


### PR DESCRIPTION
I have noticed that after switching away and back to a fugitive commit buffer the cursor shifts up.
For example
```
vim --clean -c "set runtimepath+=$PWD nofoldenable | \
    so plugin/fugitive.vim | e README.markdown | Gedit HEAD | $"
```
starts with a cursor on the last line, but after `:b # | b #` the cursor is one line up.
Adding lockmarks to `fugitive#BufReadCmd` seems to fix that.