### PR TITLE
Add Azure DevOps :GBrowse extension to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,8 +58,8 @@ Additional commands are provided for higher level operations:
   hosting provider, with optional line range (try it in visual mode).  Plugins
   are available for popular providers such as [GitHub][rhubarb.vim],
   [GitLab][fugitive-gitlab.vim], [Bitbucket][fubitive.vim],
-  [Gitee][fugitive-gitee.vim], [Pagure][pagure], and
-  [Phabricator][vim-phabricator].
+  [Gitee][fugitive-gitee.vim], [Pagure][pagure],
+  [Phabricator][vim-phabricator], and [Azure DevOps][fugitive-azure-devops.vim].
 
 [rhubarb.vim]: https://github.com/tpope/vim-rhubarb
 [fugitive-gitlab.vim]: https://github.com/shumphrey/fugitive-gitlab.vim
@@ -67,6 +67,7 @@ Additional commands are provided for higher level operations:
 [fugitive-gitee.vim]: https://github.com/linuxsuren/fugitive-gitee.vim
 [pagure]: https://github.com/FrostyX/vim-fugitive-pagure
 [vim-phabricator]: https://github.com/jparise/vim-phabricator
+[fugitive-azure-devops.vim]: https://github.com/cedarbaum/fugitive-azure-devops.vim
 
 Add `%{FugitiveStatusline()}` to `'statusline'` to get an indicator
 with the current branch in your statusline.


### PR DESCRIPTION
Add reference in README to [fugitive-azure-devops.vim](https://github.com/cedarbaum/fugitive-azure-devops.vim), which provides `GBrowse` functionality for Azure DevOps Git repositories.