### PR TITLE
Fix bug where StageIgnore Gsplits an invalid fugitive-object

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3647,7 +3647,7 @@ function! s:StageIgnore(lnum1, lnum2, count) abort
     call extend(paths, info.relative)
   endfor
   call map(paths, '"/" . v:val')
-  exe 'Gsplit' (a:count ? '.gitignore' : '.git/info/exclude')
+  exe 'split' (a:count ? '.gitignore' : '.git/info/exclude')
   let last = line('$')
   if last == 1 && empty(getline(1))
     call setline(last, paths)


### PR DESCRIPTION
when using `1gI` or `1gi`, `s:StageIgnore` attempts to execute `Gsplit .gitignore`, which results in the error 
```
fatal: 0000000000000000000000000000000000000000 is neither a commit nor blob(master)
```
and subsequently
```
Error detected while processing function <SNR>56_StageIgnore:
line    9:
E21: Cannot make changes, 'modifiable' is off
```
using `split` instead of `Gsplit` fixes this, although I'm not sure if there is a more idiomatic fix?