### PR TITLE
Fix ternary expression in s:NullError

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -554,7 +554,7 @@ endfunction
 function! s:NullError(...) abort
   let [out, exec_error] = s:SystemError(call('fugitive#Prepare', a:000))
   if exec_error
-    return [[], substitute(out, "\n$", "", "") : '', exec_error]
+    return [[], substitute(out, "\n$", "", ""), exec_error]
   else
     let list = split(out, "\1", 1)
     call remove(list, -1)


### PR DESCRIPTION
Only the leading part was removed in ae6f84a.

Fixes #1785
