### PR TITLE
Don't execute autocommands during :GBrowse with a range

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -6465,7 +6465,7 @@ function! fugitive#BrowseCommand(line1, count, range, bang, mods, arg, args) abo
             let blame_list = tempname()
             call writefile([commit, ''], blame_list, 'b')
             let blame_in = tempname()
-            silent exe '%write' blame_in
+            silent exe 'noautocmd keepalt %write' blame_in
             let [blame, exec_error] = s:LinesError(['-c', 'blame.coloring=none', 'blame', '--contents', blame_in, '-L', line1.','.line2, '-S', blame_list, '-s', '--show-number', './' . path], dir)
             if !exec_error
               let blame_regex = '^\^\x\+\s\+\zs\d\+\ze\s'


### PR DESCRIPTION
It's common to have the editor automatically format files on write with an autocommand on `BufWritePre`, for example. However, when calling e.g. `:.GBrowse`, the autocommand is also executed because GBrowse needs to write the file to compute a blame, sometimes resulting in messed up blame should the formatter be run, which happens to me often when working on other people's projects which don't use formatters, or use different settings and so on. I've also added `keepalt` for good measure.