### PR TITLE
Add :Gx, :Gwa, :Gwqa and :Gxa commands

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -166,6 +166,11 @@ that are part of Git repositories).
 :Gwq! [path]            Like |:Gwrite|! followed by |:quit|! if the write
 :Gx! [path]             succeeded.
 
+                                                *:Gwa* *:Gwqa* *:Gxa*
+:Gwa[!]                 The commands work accordingly *:wa* *:wqa* and *:xa*
+:Gwqa[!]                commands. Each stages the changes in all active
+:Gxa[!]                 buffers. *:Gwqa* and *:Gxa* additionally |:quit|.
+
                                                 *:Gdiffsplit*
 :Gdiffsplit [object]    Perform a |vimdiff| against the given file, or if a
                         commit is given, the current file in that commit.

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -147,24 +147,24 @@ that are part of Git repositories).
 :{range}Gread! [args]   |:read| the output of a Git command after {range}.
 
                                                 *:Gwrite* *fugitive-:Gw*
-:Gwrite                 Write to the current file's path and stage the results.
+:Gw[rite]               Write to the current file's path and stage the results.
                         When run in a work tree file, it is effectively git
                         add.  Elsewhere, it is effectively git-checkout.  A
                         great deal of effort is expended to behave sensibly
                         when the work tree or index version of the file is
                         open in another buffer.
 
-:Gwrite {path}          You can give |:Gwrite| an explicit path of where in
+:Gw[rite] {path}        You can give |:Gwrite| an explicit path of where in
                         the work tree to write.  You can also give a path like
                         :0:foo.txt or :0:% to write to just that stage in
                         the index.
 
-                                                *:Gwq*
+                                                *:Gwq* *:Gx*
 :Gwq [path]             Like |:Gwrite| followed by |:quit| if the write
-                        succeeded.
+:Gx [path]              succeeded.
 
 :Gwq! [path]            Like |:Gwrite|! followed by |:quit|! if the write
-                        succeeded.
+:Gx! [path]             succeeded.
 
                                                 *:Gdiffsplit*
 :Gdiffsplit [object]    Perform a |vimdiff| against the given file, or if a

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -461,6 +461,7 @@ exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gvd
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gw     exe fugitive#WriteCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gwrite exe fugitive#WriteCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gwq    exe fugitive#WqCommand(   <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
+exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gx     exe fugitive#WqCommand(   <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 
 exe 'command! -bar -bang -nargs=0 GRemove exe fugitive#RemoveCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=0 GDelete exe fugitive#DeleteCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'

--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -463,6 +463,10 @@ exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gwr
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gwq    exe fugitive#WqCommand(   <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gx     exe fugitive#WqCommand(   <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 
+exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gwa  exe "wa" | let s:curBuf=bufnr("%") | bufdo exe fugitive#WriteCommand( <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, []) | exe "buffer" . s:curBuf'
+exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gwqa exe "wa" | bufdo! exe fugitive#WqCommand(  <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, []) | exe "q"'
+exe 'command! -bar -bang -nargs=* -complete=customlist,fugitive#EditComplete Gxa  exe "wa" | bufdo! exe fugitive#WqCommand(  <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, []) | exe "q"'
+
 exe 'command! -bar -bang -nargs=0 GRemove exe fugitive#RemoveCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=0 GDelete exe fugitive#DeleteCommand(<line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'
 exe 'command! -bar -bang -nargs=1 -complete=customlist,fugitive#CompleteObject GMove   exe fugitive#MoveCommand(  <line1>, <count>, +"<range>", <bang>0, "<mods>", <q-args>, [<f-args>])'


### PR DESCRIPTION
Hey dear Tim,
I'd like to improve UX a little bit.

In the patch, I've added `:Gwa` command that I miss so much in the daily work. At the same time, to save some keystrokes and provide the same behavior as vim, I've added `:Gx[a]` commands.

Hopefully, you find it useful!