### PR TITLE
Remove unnecessary `echo`

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5136,7 +5136,6 @@ function! fugitive#LogComplete(A, L, P) abort
 endfunction
 
 function! s:GrepParseLine(options, dir, line) abort
-  echo a:line
   let entry = {'valid': 1}
   let match = matchlist(a:line, '^\(.\{-\}\):\([1-9]\d*\):\([1-9]\d*:\)\=\(.*\)$')
   if len(match)


### PR DESCRIPTION
This `echo`, added in https://github.com/tpope/vim-fugitive/commit/286bf9096de0d74a5b663f2c6d4ae879ef97d93b, changed the behaviour of `Ggrep` for me. It means every line found is echoed, and I need to scroll to the bottom of this output (when there are a lot of results) in order to be able to hit enter and have my quickfix window populated with the grep results, whereas previously I could just hit enter to have this happen immediately.

This commit removes this to restore the previous behaviour; I'm guessing this was for debugging but was accidentally left here - unless I'm missing some reason this is actually needed.

Thanks!
