### PR TITLE
Fix default remote in fugitive#RemoteUrl

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -1342,7 +1342,8 @@ function! fugitive#RemoteUrl(...) abort
   let config = fugitive#Config(dir_or_config)
   if url =~# '^\.\=$'
     let url = s:RemoteDefault(config)
-  elseif url ==# '.git'
+  endif
+  if url ==# '.git'
     let url = s:GitDir(config)
   elseif url !~# ':\|^/\|^\.\.\=/'
     let url = FugitiveConfigGet('remote.' . url . '.url', config)


### PR DESCRIPTION
A previous refactor resulted in fugitive#RemoteUrl() with no arguments
returning the string 'origin' instead of git@github.com....

1352646 factored out some of the code, but the logic around no arguments and default remote seems to have broken in that commit.