### PR TITLE
[bugfix] `:G` command fails in netrw directory window

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -415,6 +415,8 @@ function! FugitiveExtractGitDir(path) abort
     return ''
   elseif path !~# '^/\|^\a\+:'
     let path = s:Slash(getcwd()) . '/' . path
+  elseif isdirectory(path) && path !~# '/$'
+    let path += '/'
   endif
   let path = fnamemodify(path, ':h')
   let pre = substitute(matchstr(path, '^\a\a\+\ze:'), '^.', '\u&', '')


### PR DESCRIPTION
`:G` command fails in a window of directory
saying `fugitive: file does not belong to a Git repository`.

The commit 1b811b88a45ff7b906ea9314adf016883ce5cd9e invites this.

It replaces path `:p` modification, but it changes something.

It looks directory-`:p`-path is added trailing `/` (`/c/xxxxx/dir` -> `/c/xxxxx/dir/`).
Without `/`, it probably thinks the path is a file.

How to Repro
--------------------------------------------------------------------------------

```bash
% cd GIT_REPOSITORY
% vim ./
# This opens the `GIT_REPOSITORY` directory by netrw plugin
```

```vim
" The git directory `GIT_REPOSITORY` window is focused
:G

" ERROR: Then, the command fails.

"----

:e SOME_FILE_IN_THE_DIR.md
:G

" SUCCESS: It works successfully.
```

Environment
--------------------------------------------------------------------------------

- Windows 10 Pro 21H2 (x64)
    - Microsoft Windows [Version 10.0.19044.1645]
- Git for Windows: version 2.36.0.windows.1
