### PR TITLE
Add: recreate commit message map

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7573,6 +7573,7 @@ function! fugitive#MapJumps(...) abort
     call s:Map('n', 'ca', ':<C-U>Git commit --amend<CR>', '<silent>')
     call s:Map('n', 'cc', ':<C-U>Git commit<CR>', '<silent>')
     call s:Map('n', 'ce', ':<C-U>Git commit --amend --no-edit<CR>', '<silent>')
+    call s:Map('n', 'cd', ':<C-U>Git commit --edit --file .git/COMMIT_EDITMSG<CR>', '<silent>')
     call s:Map('n', 'cw', ':<C-U>Git commit --amend --only<CR>', '<silent>')
     call s:Map('n', 'cva', ':<C-U>tab Git commit -v --amend<CR>', '<silent>')
     call s:Map('n', 'cvc', ':<C-U>tab Git commit -v<CR>', '<silent>')

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -460,6 +460,8 @@ ca                      Amend the last commit and edit the message.
 
 ce                      Amend the last commit without editing the message.
 
+cd                      Recreate commit using previously failed commit message.
+
 cw                      Reword the last commit.
 
 cvc                     Create a commit with -v.


### PR DESCRIPTION
`cd` for recreating the commit using the commit message from
`.git/COMMIT_EDITMSG` .

Fixes #1608

Hope this isn't too pushy. I just thought I'd try to create a fix, instead of submitting a feature request.

If there's a better way to add my own fugitive maps, then by all means please reject this PR if you don't see any value to it. But please let me know how to create my own fugitive maps, as I've tried to search the github issues and the help files for this information.