### PR TITLE
Fix Git blame not being able to show commits on Windows

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2550,6 +2550,13 @@ augroup END
 function! s:ReplaceCmd(cmd) abort
   let temp = tempname()
   let [err, exec_error] = s:StdoutToFile(temp, a:cmd)
+  if has('win32')
+    " on win32, we might get a short 8.3 path, which will have a ~ which will
+    " blow up on the read command further down. The following call to
+    " fnamemodify will expand the 8.3 paths *if* the file exists, so we only
+    " call it after writing the file in the line above
+    let temp = fnamemodify(temp, ':p')
+  endif
   if exec_error
     throw 'fugitive: ' . (len(err) ? substitute(err, "\n$", '', '') : 'unknown error running ' . string(a:cmd))
   endif


### PR DESCRIPTION
If the username is long enough that the home directory gets truncated to an 8.3 path (e.g: C:/Users/ABCDEF~1), Git blame will fail on the silent :read command due to the ~ character.

Expand the path to a full path after the file exists, on Windows, to fix it.