### PR TITLE
`cn<Space>` to create a commit with `--no-verify`

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7682,6 +7682,7 @@ function! fugitive#MapJumps(...) abort
     call s:Map('x', 'gi',    ":<C-U>exe 'Gsplit' (v:count ? '.gitignore' : '.git/info/exclude')<CR>", '<silent>')
 
     call s:Map('n', 'c<Space>', ':Git commit<Space>')
+    call s:Map('n', 'cn<Space>', ':Git commit --no-verify<CR>')
     call s:Map('n', 'c<CR>', ':Git commit<CR>')
     call s:Map('n', 'cv<Space>', ':tab Git commit -v<Space>')
     call s:Map('n', 'cv<CR>', ':tab Git commit -v<CR>')

--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -478,6 +478,8 @@ cA                      Create a `squash!` commit for the commit under the
 
 c<Space>                Populate command line with ":Git commit ".
 
+cn<Space>               Create a commit without running git hooks.
+
                                                 *fugitive_cr*
 crc                     Revert the commit under the cursor.
 


### PR DESCRIPTION
I'm working on a large project and I can't disable the hooks, but find myself typing `:Git commit --no-verify` more often than I want and thought others might have been looking for this also...

I _love_ this tool @tpope - thank you for creating it