### PR TITLE
Tighten match for commit under cursor

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7553,7 +7553,7 @@ function! s:SquashArgument(...) abort
   if &filetype == 'fugitive'
     let commit = matchstr(getline('.'), '^\%(\%(\x\x\x\)\@!\l\+\s\+\)\=\zs[0-9a-f]\{4,\}\ze \|^' . s:ref_header . ': \zs\S\+')
   elseif has_key(s:temp_files, s:cpath(expand('%:p')))
-    let commit = matchstr(getline('.'), '\S\@<!\x\{4,\}\>')
+    let commit = matchstr(getline('.'), '\S\@<!\x\{4,\}\S\@!')
   else
     let commit = s:Owner(@%)
   endif


### PR DESCRIPTION
Using `coo` to open a branch under the cursor that started with 4+ hex
digits (e.g., 1111-feat) would fail with the error `fatal: invalid reference: 
1111.`

This happened because the prior regex would consider these branch names
 as commits when determining whether to treat what was under the cursor
 as a branch or commit.

This changes the regex to use a negative look-ahead to further tighten
 the match for a commit and require that a match on 4+ hex digits also
not end with a non-hex digit.

Resolves #2085.