### PR TITLE
Fix parsing of diff hunk headers with omitted length

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7599,7 +7599,7 @@ function! s:HunkPosition(lnum) abort
     let lnum -= 1
     let line_char = getline(lnum)[0]
   endwhile
-  let starts = matchlist(getline(lnum), '^@@\+[ 0-9,-]* -\(\d\+\),\d\+ +\(\d\+\),')
+  let starts = matchlist(getline(lnum), '^@@\+[ 0-9,-]* -\(\d\+\)\%(,\d\+\)\= +\(\d\+\)[ ,]')
   if empty(starts)
     return [0, 0, 0]
   endif


### PR DESCRIPTION
7dd76231e65b59da66a35cd6caed30edf015aec5 made the comma and the second
number required in a line range. But they can be omitted, for example:

* Adding a single line file:

    @@ -0,0 +1 @@

* Modifying a single line file:

    @@ -1 +1 @@
