### PR TITLE
Add "P" command to Git blame documentation

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -70,6 +70,7 @@ that are part of Git repositories).
                         O     jump to patch or blob in new tab
                         p     jump to patch or blob in preview window
                         -     reblame at commit
+                        P     reblame at parent commit                             
 
                                                 *g:fugitive_dynamic_colors*
                         In the GUI or a 256 color terminal, commit hashes will


### PR DESCRIPTION
I found out about the command from https://advancedweb.hu/dive-into-git-history-with-fugitive-vim/, and I wish it was in the manual.