### PR TITLE
Fix dropped quote of `entries`

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -2922,7 +2922,7 @@ function! fugitive#BufReadStatus(...) abort
 
     let unpushed_push = s:QueryLogRange(push_ref ==# pull_ref ? '' : push_ref, head)
     if get(props, 'branch.ab') =~# '^+0 '
-      let unpushed_pull = {'error': 0, 'overflow': 0, entries: []}
+      let unpushed_pull = {'error': 0, 'overflow': 0, 'entries': []}
     else
       let unpushed_pull = s:QueryLogRange(pull_ref, head)
     endif


### PR DESCRIPTION
Quote is forgotten for dict key name.

It makes an error as blow on `:G`:

```
Error detected while processing command line..BufReadCmd Autocommands for "fugitive://*"..function fugitive#BufReadCmd[128]..command line..BufReadCmd Autocommands for "fugitive://*"..function fugitive#BufReadCmd[9]..fugitive#BufReadStatus:
line  255:
E121: Undefined variable: entries
```
