### PR TITLE
Use the dir variable in fugitive#Head

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -1027,7 +1027,7 @@ function! fugitive#Head(...) abort
   if empty(dir)
     return ''
   endif
-  let file = FugitiveActualDir() . '/HEAD'
+  let file = FugitiveActualDir(dir) . '/HEAD'
   let ftime = getftime(file)
   if ftime == -1
     return ''


### PR DESCRIPTION
I believe this is the solution to a minor bug where the `dir` variable was created but not used properly in `fugitive#Head`.