### PR TITLE
Show commit stat to quickly view files of the commit

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3155,7 +3155,10 @@ function! fugitive#BufReadCmd(...) abort
         if b:fugitive_display_format
           call s:ReplaceCmd([dir, 'cat-file', b:fugitive_type, rev])
         else
-          call s:ReplaceCmd([dir, '-c', 'diff.noprefix=false', '-c', 'log.showRoot=false', 'show', '--no-color', '-m', '--first-parent', '--pretty=format:tree%x20%T%nparent%x20%P%nauthor%x20%an%x20<%ae>%x20%ad%ncommitter%x20%cn%x20<%ce>%x20%cd%nencoding%x20%e%n%n%s%n%n%b', rev])
+          call s:ReplaceCmd([dir, '-c', 'diff.noprefix=false', '-c', 'log.showRoot=false',
+                      \ 'show', '--stat', '--patch', '--no-color',
+                      \ '-m', '--first-parent',
+                      \ '--pretty=format:tree%x20%T%nparent%x20%P%nauthor%x20%an%x20<%ae>%x20%ad%ncommitter%x20%cn%x20<%ce>%x20%cd%nencoding%x20%e%n%n%s%n%n%b', rev])
           keepjumps 1
           keepjumps call search('^parent ')
           if getline('.') ==# 'parent '


### PR DESCRIPTION
Hello,

Here is a small PR to use `git show --stat --patch` to quickly see which files are affected by a commit.
I am not really sure that the location of the modification is the right place to do it :grin: 

Related to issue #2154

Cheers