### PR TITLE
Always fire BufReadStatus's autocmd

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -4265,7 +4265,7 @@ function! s:ReloadStatusBuffer(...) abort
   endif
   let original_lnum = a:0 ? a:1 : line('.')
   let info = s:StageInfo(original_lnum)
-  call fugitive#BufReadStatus(0)
+  exe fugitive#BufReadStatus(0)
   call setpos('.', [0, s:StageSeek(info, original_lnum), 1, 0])
   return ''
 endfunction


### PR DESCRIPTION
Fix #2161.

Always execute BufReadStatus's return value because that's the code that fires the FugitiveIndex autocmd.