### PR TITLE
Docs: Escape `<` character in help.txt

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -302,7 +302,7 @@ X                       Discard the change under the cursor.  This uses
 >                       Insert an inline diff of the file under the cursor.
 
                                                 *fugitive_<*
-<                       Remove the inline diff of the file under the cursor.
+<<                       Remove the inline diff of the file under the cursor.
 
                                                 *fugitive_gI*
 gI                      Open .git/info/exclude in a split and add the file


### PR DESCRIPTION
Escaping issue seem to be causing the `<` character not to be rendered in helptext for the "remove inline diff" command, see screenshots in PR

Using neovim

```
$ nvim --version
NVIM v0.9.0
Build type: Release
LuaJIT 2.1.0-beta3
```

Current `:h fugitive` rendering:
![before](https://github.com/tpope/vim-fugitive/assets/823316/d03fa8c1-cc52-4b6c-a15f-67608bd79601)

After this change:
![after](https://github.com/tpope/vim-fugitive/assets/823316/0c3e8bb4-731a-43d3-84ff-efa5cb1cc630)
