### PR TITLE
If in `netrw`, extract `git` directory from `netrw_curdir`

### DIFF
--- a/plugin/fugitive.vim
+++ b/plugin/fugitive.vim
@@ -23,8 +23,12 @@ function! FugitiveGitDir(...) abort
       return g:fugitive_event
     endif
     let dir = get(b:, 'git_dir', '')
-    if empty(dir) && (empty(bufname('')) || &buftype =~# '^\%(nofile\|acwrite\|quickfix\|terminal\|prompt\)$')
-      return FugitiveExtractGitDir(getcwd())
+    if empty(dir)
+        if &filetype ==# 'netrw' && exists('b:netrw_curdir')
+            return FugitiveExtractGitDir(b:netrw_curdir)
+        elseif empty(bufname('')) || &buftype =~# '^\%(nofile\|acwrite\|quickfix\|terminal\|prompt\)$'
+            return FugitiveExtractGitDir(getcwd())
+        endif
     elseif (!exists('b:git_dir') || b:git_dir =~# s:bad_git_dir) && &buftype =~# '^\%(nowrite\)\=$'
       let b:git_dir = FugitiveExtractGitDir(bufnr(''))
       return b:git_dir


### PR DESCRIPTION
First of all, thank you for this and all your other plugins! 

## The problem

When in a `netrw` window, `:G` complains that `fugitive: file does not belong to a Git repository.`

## This PR

This PR fixes the issue; or at least, it does so for me :)

I am not really knowledgeable in `vimscript`, so maybe there are better / less special ways to achieve the same.

## Test

To test:

```bash
mkdir /tmp/fgtv
cd /tmp/fgtv
git init
echo "let &rtp = '~/.vim/plugged/vim-fugitive,' . &rtp" > test.vim  # or replace with your path
nvim --clean -u test.vim .

:G
```