### PR TITLE
Small code clean up: Remove unneeded "syntax include" statement.

### DIFF
--- a/syntax/fugitive.vim
+++ b/syntax/fugitive.vim
@@ -5,8 +5,6 @@ endif
 syn sync fromstart
 syn spell notoplevel
 
-syn include @fugitiveDiff syntax/diff.vim
-
 syn match fugitiveHeader /^[A-Z][a-z][^:]*:/
 syn match fugitiveHeader /^Head:/ nextgroup=fugitiveHash,fugitiveSymbolicRef skipwhite
 syn match fugitiveHeader /^Pull:\|^Rebase:\|^Merge:\|^Push:/ nextgroup=fugitiveSymbolicRef skipwhite


### PR DESCRIPTION
@fugitiveDiff hasn't been used since 0868c30cc08a4cf49b5f43e08412c671b19fa3f0.