### PR TITLE
Document opening diff split from patch

### DIFF
--- a/doc/fugitive.txt
+++ b/doc/fugitive.txt
@@ -357,6 +357,8 @@ Navigation maps ~
                         removed if a count was given.  If the line is still in
                         the work tree version, passing a count takes you to
                         it.
+                        On the 'diff --git' line of a patch, this and similar
+                        maps open a |:Gdiffsplit|.
 
                                                 *fugitive_o*
 o                       Open the file or |fugitive-object| under the cursor in


### PR DESCRIPTION
References #2219.

There's awesome special behaviour for buffers with diff output to view it in a split diff instead of unified diff.

Let me know if my terminology needs correcting.

I also thought it was great that I could `set foldmethod=syntax foldlevel=0` to collapse diffs down to a list of files that you can press `o` to open in a split diff. But that seems excessively detailed for the doc.