### PR TITLE
Buffer output when using the pager

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3933,6 +3933,8 @@ function! fugitive#Command(line1, line2, range, bang, mods, arg, ...) abort
       let job = jobstart(argv, extend(jobopts, {
             \ 'pty': state.pty,
             \ 'TERM': 'dumb',
+            \ 'stdout_buffered': pager,
+            \ 'stderr_buffered': pager,
             \ 'on_stdout': function('s:RunReceive', [state, tmp, 'out']),
             \ 'on_stderr': function('s:RunReceive', [state, tmp, 'err']),
             \ 'on_exit': function('s:RunClose', [state, tmp]),


### PR DESCRIPTION
As of 10ed587f655578657e203735a9e439e823aab5fc all output is captured to a temp file before being displayed. When the output is not buffered, the stdout/stderr callback is called to perform post-processing for each output chunk. Instead, buffer all output and perform the post-processing all at once.

This results in a substantial performance improvement for repositories with many commits.

---

I tested this with `nvim` on https://github.com/neovim/neovim, which has just over 28000 commits. I used the following script to profile:

**profile.vim**

```vim
profile start profile.log
profile func *
profile file *
Git log
profile pause
noautocmd qall!
```

Then ran `nvim -S profile.vim`.

Results on `master`:

```
FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    1   7.074022   0.000029  fugitive#Resume()
    1   7.073993   0.126769  <SNR>67_RunWait()
 1107   6.939090   0.206153  <SNR>67_RunTick()
 1285   6.732937             <SNR>67_RunReceive()
    2   0.239005   0.001420  <SNR>9_SynSet()
    1   0.126997   0.000150  <SNR>67_TempReadPost()
    1   0.033617   0.010282  fugitive#Command()
    7   0.011313   0.010272  fugitive#Wait()
    3   0.007767   0.001146  <SNR>67_JobExecute()
    1   0.007271   0.007267  <SNR>67_TempScript()
    4   0.006975   0.000130  fugitive#Config()
    2   0.006359   0.000096  <SNR>57_Init()
    1   0.006258   0.000003  <SNR>57_AutoInit()
  142   0.006229             <SNR>67_Map()
 1107   0.006081             <SNR>67_RunEcho()
    1   0.005901   0.000121  fugitive#MapJumps()
    2   0.005604   0.000097  <SNR>57_DetectHeuristics()
    1   0.005498             <SNR>57_Guess()
    5   0.004175   0.000095  fugitive#GitVersion()
    1   0.004125   0.000015  <SNR>67_VersionCheck()
```

With this PR:

```
FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
    1   0.516061   0.000012  fugitive#Resume()
    1   0.516049   0.000726  <SNR>67_RunWait()
   26   0.514810   0.474789  <SNR>67_RunTick()
    2   0.241792   0.003784  <SNR>9_SynSet()
    1   0.125955   0.000032  <SNR>67_TempReadPost()
    1   0.040749   0.018985  fugitive#Command()
    2   0.040021             <SNR>67_RunReceive()
    7   0.011335   0.010336  fugitive#Wait()
    3   0.007888   0.001102  <SNR>67_JobExecute()
    4   0.006690   0.000130  fugitive#Config()
    2   0.006510   0.000093  <SNR>57_Init()
    1   0.006399   0.000003  <SNR>57_AutoInit()
  142   0.005999             <SNR>67_Map()
    1   0.005899   0.005896  <SNR>67_TempScript()
    1   0.005794   0.000183  fugitive#MapJumps()
    2   0.005607   0.000083  <SNR>57_DetectHeuristics()
    1   0.005515             <SNR>57_Guess()
    5   0.004442   0.000094  fugitive#GitVersion()
    1   0.004392   0.000015  <SNR>67_VersionCheck()
    1   0.003832   0.000016  <SNR>67_AskPassArgs()
```
