### PR TITLE
Fix misaligned output of :G blame -s

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7210,7 +7210,7 @@ function! fugitive#BlameSyntax() abort
   exec 'syn match FugitiveblameOriginalFile       "\s\%(\f\+\D\@<=\|\D\@=\f\+\)\%(\%(\s\+\d\+\)\=\s\%((\|\s*\d\+)\)\)\@=" contained nextgroup=FugitiveblameOriginalLineNumber,FugitiveblameAnnotation skipwhite' (s:HasOpt(flags, '--show-name', '-f') ? '' : conceal)
   exec 'syn match FugitiveblameOriginalLineNumber "\s*\d\+\%(\s(\)\@=" contained nextgroup=FugitiveblameAnnotation skipwhite' (s:HasOpt(flags, '--show-number', '-n') ? '' : conceal)
   exec 'syn match FugitiveblameOriginalLineNumber "\s*\d\+\%(\s\+\d\+)\)\@=" contained nextgroup=FugitiveblameShort skipwhite' (s:HasOpt(flags, '--show-number', '-n') ? '' : conceal)
-  syn match FugitiveblameShort              " \d\+)" contained contains=FugitiveblameLineNumber
+  syn match FugitiveblameShort              " \+\d\+)" contained contains=FugitiveblameLineNumber
   syn match FugitiveblameNotCommittedYet "(\@<=Not Committed Yet\>" contained containedin=FugitiveblameAnnotation
   hi def link FugitiveblameBoundary           Keyword
   hi def link FugitiveblameHash               Identifier


### PR DESCRIPTION
When I do `:G blame -s` on a large file, the parentheses after the line numbers are misaligned, leading to ugly output and a too-wide buffer:

![blame1](https://github.com/tpope/vim-fugitive/assets/8935863/2eb511cb-3c7a-41e3-a799-7d9e21dab74e)

It looks like what's happening is the syntax isn't matching the spaces before the line numbers (highlighted below with `conceallevel=0`), so they aren't getting concealed:

![blame2](https://github.com/tpope/vim-fugitive/assets/8935863/0256f431-b00e-452e-9945-7e6ae37763ba)