### PR TITLE
Fix issue where fugitive resets "last accessed tab" status

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -4362,9 +4362,13 @@ function! fugitive#DidChange(...) abort
   if a:0 > 1 ? a:2 : (!a:0 || a:1 isnot# 0)
     let t = reltime()
     let t:fugitive_reload_status = t
+    let prevnr = tabpagenr('#')
     for tabnr in range(1, tabpagenr('$'))
-      call settabvar(tabnr, 'fugitive_reload_status', t)
+      if tabnr != prevnr
+        call settabvar(tabnr, 'fugitive_reload_status', t)
+      endif
     endfor
+    call settabvar(prevnr, 'fugitive_reload_status', t)
     call s:ReloadTabStatus()
   else
     call s:ReloadWinStatus()


### PR DESCRIPTION
I have experienced a recurring bug when trying to jump to the "last accessed tab" with `:tabnext #` where vim seems to randomly forget the access history and jump to the right-most tab instead. I recently discovered that setting tab-page-scope variables with `settabvar(tabnr, ...)` gives `tabnr` this "last accessed" status, and after grepping `~/.vim`, it seems `vim-fugitive` was causing this behavior by iterating over all tabs and calling `settabvar()` for each one.

This PR preserves "last accessed tab" status by setting the `tabpagenr('#')` tab-scope variable after all the other tab variables. Note that if the "previous tab" is unset then `tabpagenr('#')` returns `0` and `settabvar(...)` fails silently.