### PR TITLE
Fix TempReadPost return value

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3352,6 +3352,7 @@ function! s:TempReadPost(file) abort
     endif
     return 'doautocmd <nomodeline> User FugitivePager'
   endif
+  return ''
 endfunction
 
 function! s:TempDelete(file) abort


### PR DESCRIPTION
Commit 2377e16 does not add return for normal buffer case, so it will return 0 and `exe 0` will set the cursor to the top. It will undo cursor position setting from user's BufReadPost autocommand.