### PR TITLE
Fix syntax error in autoload/fugitive.vim

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -5466,7 +5466,7 @@ function! s:ToolItems(state, from, to, offsets, text, ...) abort
     endif
     call add(items, item)
   endfor
-  if get(offsets, 0, 0) >= 0
+  if get(a:offsets, 0, 0) >= 0
     let items[-1].context = {'diff': items[0:-2]}
   endif
   return [items[-1]]


### PR DESCRIPTION
The error was introduced in ed9e21fb9bdbda7989c1c9190ca830d36a5df4e2