### PR TITLE
Format the full body instead of separating title from body

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3185,7 +3185,7 @@ function! fugitive#BufReadCmd(...) abort
         if b:fugitive_display_format
           call s:ReplaceCmd([dir, 'cat-file', b:fugitive_type, rev])
         else
-          call s:ReplaceCmd([dir, '-c', 'diff.noprefix=false', '-c', 'log.showRoot=false', 'show', '--no-color', '-m', '--first-parent', '--pretty=format:tree%x20%T%nparent%x20%P%nauthor%x20%an%x20<%ae>%x20%ad%ncommitter%x20%cn%x20<%ce>%x20%cd%nencoding%x20%e%n%n%s%n%n%b', rev])
+          call s:ReplaceCmd([dir, '-c', 'diff.noprefix=false', '-c', 'log.showRoot=false', 'show', '--no-color', '-m', '--first-parent', '--pretty=format:tree%x20%T%nparent%x20%P%nauthor%x20%an%x20<%ae>%x20%ad%ncommitter%x20%cn%x20<%ce>%x20%cd%nencoding%x20%e%n%n%B', rev])
           keepjumps 1
           keepjumps call search('^parent ')
           if getline('.') ==# 'parent '


### PR DESCRIPTION
Fix #2315: Gedit strips newlines when commit lacks a blank line

`%B` is the "raw body (unwrapped subject and body)". Since we're displaying both, we can use that to avoid any changes to the message content. %B was added to git in 1.7.2 (2010) in commit 1367b12ad623e28546ba40c435015d94e7fbb248, and fugitive requires 1.8.5 so it's safe to use.

Used it a bit yesterday and don't see anything wrong. `:Gedit HEAD` shows the commit message as expected:

```
tree f966952d7e0715683ee935d201cd4ab22736c831
author idbrii<idbrii@example.com> 2024-07-03 Wed 01:06:34 PM
committer idbrii<idbrii@example.com> 2024-07-03 Wed 01:06:34 PM

Capitalized, short (50 chars or less) summary
More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, followed by a
  single space, with blank lines in between, but conventions vary here
- Use a hanging indent
```

Diffed against how it looked before this commit and properly formatted commits are identical.