### PR TITLE
feat: support vim.ui.open for GBrowse on Neovim

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7433,6 +7433,8 @@ function! s:BrowserOpen(url, mods, echo_copy) abort
     return 'echo '.string(url).'|' . mods . 'Browse '.url
   elseif exists(':OpenBrowser') == 2
     return 'echo '.string(url).'|' . mods . 'OpenBrowser '.url
+  elseif has('nvim-0.10')
+    return 'echo '.string(url).'|' . mods . 'lua vim.ui.open('.string(url).')'
   else
     if !exists('g:loaded_netrw')
       runtime! autoload/netrw.vim


### PR DESCRIPTION
It is not uncommon for Neovim users to have netrw disabled in favor of other file explorers. When this is the case, `:GBrowse` fails. Neovim 0.10 ships with a new [vim.ui.open](https://neovim.io/doc/user/lua.html#vim.ui.open()) helper method that is designed to replace this exact functionality.

This PR simply preferentially uses `vim.ui.open` in Neovim 0.10+ over netrw. I have tested it with a simple `:GBrowse` in a file and it appears to work well.