### PR TITLE
Disable modelines for status buffers

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3060,7 +3060,7 @@ function! fugitive#BufReadStatus(cmdbang) abort
     let b:fugitive_loading = stat
     doautocmd <nomodeline> BufReadPre
 
-    setlocal readonly nomodifiable noswapfile nomodifiable buftype=nowrite
+    setlocal readonly nomodifiable noswapfile nomodeline buftype=nowrite
     call s:MapStatus()
 
     call s:StatusRender(stat)


### PR DESCRIPTION
Regression introduced in 8c8cdf4405cb8bdb70dd9812a33bb52363a87dbc.
Resolves: https://github.com/tpope/vim-fugitive/issues/2333