### PR TITLE
Support opting out of deprecated mappings

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -8012,7 +8012,7 @@ function! fugitive#MapJumps(...) abort
       call s:Map('n', 'O',    ':<C-U>exe <SID>GF("tabedit")<CR>', '<silent>')
       call s:Map('n', 'p',    ':<C-U>exe <SID>GF("pedit")<CR>', '<silent>')
 
-      if !exists('g:fugitive_no_maps')
+      if get(g:, 'fugitive_legacy_mappings', 1) && !exists('g:fugitive_no_maps')
         call s:Map('n', '<C-P>', ':exe <SID>PreviousItem(v:count1)<Bar>echohl WarningMsg<Bar>echo "CTRL-P is deprecated in favor of ("<Bar>echohl NONE<CR>', '<unique>')
         call s:Map('n', '<C-N>', ':exe <SID>NextItem(v:count1)<Bar>echohl WarningMsg<Bar>echo "CTRL-N is deprecated in favor of )"<Bar>echohl NONE<CR>', '<unique>')
       endif


### PR DESCRIPTION
This commit follows d70c42aa503751bde3991be8d1dfc0f1819d211a to remove
the mappings that are deprecated inside of fugitive.vim. For now it is
only `<C-p>` and `<C-n>`. The user opts out by setting
`g:fugitive_legacy_mappings` to 0.