### PR TITLE
Fix GBrowse for newer Netrw versions

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7437,9 +7437,12 @@ function! s:BrowserOpen(url, mods, echo_copy) abort
   else
     if !exists('g:loaded_netrw')
       runtime! autoload/netrw.vim
+      runtime! autoload/netrw/os.vim
     endif
     if exists('*netrw#Open')
       return 'echo '.string(url).'|' . mods . 'call netrw#Open('.string(url).')'
+    elseif exists('*netrw#os#Open')
+      return 'echo '.string(url).'|' . mods . 'call netrw#os#Open('.string(url).')'
     elseif exists('*netrw#BrowseX')
       return 'echo '.string(url).'|' . mods . 'call netrw#BrowseX('.string(url).', 0)'
     elseif exists('*netrw#NetrwBrowseX')


### PR DESCRIPTION
In vim/vim@ef92555 (Netrw v182), the arity of `netrw#BrowseX` changed from 2 to 1. 

There is now a `netrw#os#Open()` function that can be used to open URLs instead. That was added in vim/vim@5b97947 (Netrw v178).

Before this, `:GBrowse` would throw E118 on Vim versions later than 9.1.1485. 

```
https://github.com/tpope/vim-fugitive/blob/master/autoload/fugitive.vim
E118: Too many arguments for function: netrw#BrowseX
```