### PR TITLE
Paginate rebase --show-current-patch

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3783,7 +3783,7 @@ function! fugitive#PagerFor(argv, ...) abort
   elseif args[0] =~# '^\%(branch\|config\|diff\|grep\|log\|range-diff\|shortlog\|show\|tag\|whatchanged\)$' ||
         \ (args[0] ==# 'stash' && get(args, 1, '') ==# 'show') ||
         \ (args[0] ==# 'reflog' && get(args, 1, '') !~# '^\%(expire\|delete\|exists\)$') ||
-        \ (args[0] ==# 'am' && s:HasOpt(args, '--show-current-patch'))
+        \ (args[0] =~# '^\%(am\|rebase\)$' && s:HasOpt(args, '--show-current-patch'))
     return 1
   else
     return 0


### PR DESCRIPTION
From git-rebase(1):

       --show-current-patch
           Show the current patch in an interactive rebase or when rebase is
           stopped because of conflicts. This is the equivalent of git show
           REBASE_HEAD.
