### PR TITLE
call BrowseX with 1 arg for patch >= 9.1.1485

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7453,7 +7453,11 @@ function! s:BrowserOpen(url, mods, echo_copy) abort
     elseif exists('*netrw#os#Open')
       return 'echo '.string(url).'|' . mods . 'call netrw#os#Open('.string(url).')'
     elseif exists('*netrw#BrowseX')
-      return 'echo '.string(url).'|' . mods . 'call netrw#BrowseX('.string(url).', 0)'
+      if has('patch-9.1.1485')
+        return 'echo '.string(url).'|' . mods . 'call netrw#BrowseX('.string(url).')'
+      else
+        return 'echo '.string(url).'|' . mods . 'call netrw#BrowseX('.string(url).', 0)'
+      endif
     elseif exists('*netrw#NetrwBrowseX')
       return 'echo '.string(url).'|' . mods . 'call netrw#NetrwBrowseX('.string(url).', 0)'
     elseif has('nvim-0.10')


### PR DESCRIPTION
https://github.com/vim/vim/commit/ef925556cbea4d54e73388da3b3e6c06a1bbcc02

patch version checked with `git tag --contains ef92555` in vim repository.

`netrw#BrowseX()` was changed in Vim patch 9.1.1485 to take a single argument and handle remote detection internally. Use one-arg call when that patch is present, and fallback to the old two-arg form for older builds.