### PR TITLE
feat: add --stat output to commit view as 0th display format

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -3228,11 +3228,26 @@ function! fugitive#BufReadCmd(...) abort
           call s:ReplaceCmd([dir, 'cat-file', '-p', rev])
         endif
       elseif b:fugitive_type ==# 'commit'
-        let b:fugitive_display_format = b:fugitive_display_format % 2
-        if b:fugitive_display_format
+        let b:fugitive_display_format = b:fugitive_display_format % 3
+        if b:fugitive_display_format == 1
           call s:ReplaceCmd([dir, 'cat-file', b:fugitive_type, rev])
-        else
+        elseif b:fugitive_display_format == 2
           call s:ReplaceCmd([dir, '-c', 'diff.noprefix=false', '-c', 'log.showRoot=false', 'show', '--no-color', '-m', '--first-parent', '--pretty=format:tree%x20%T%nparent%x20%P%nauthor%x20%an%x20<%ae>%x20%ad%ncommitter%x20%cn%x20<%ce>%x20%cd%nencoding%x20%e%n%n%B', rev])
+          keepjumps 1
+          keepjumps call search('^parent ')
+          if getline('.') ==# 'parent '
+            silent lockmarks keepjumps delete_
+          else
+            silent exe (exists(':keeppatterns') ? 'keeppatterns' : '') 'keepjumps s/\m\C\%(^parent\)\@<! /\rparent /e' . (&gdefault ? '' : 'g')
+          endif
+          keepjumps let lnum = search('^encoding \%(<unknown>\)\=$','W',line('.')+3)
+          if lnum
+            silent lockmarks keepjumps delete_
+          end
+          silent exe (exists(':keeppatterns') ? 'keeppatterns' : '') 'keepjumps 1,/^diff --git\|\%$/s/\r$//e'
+          keepjumps 1
+        else
+          call s:ReplaceCmd([dir, '-c', 'diff.noprefix=false', '-c', 'log.showRoot=false', 'show', '-p', '--stat', '--no-color', '-m', '--first-parent', '--pretty=format:tree%x20%T%nparent%x20%P%nauthor%x20%an%x20<%ae>%x20%ad%ncommitter%x20%cn%x20<%ce>%x20%cd%nencoding%x20%e%n%n%B', rev])
           keepjumps 1
           keepjumps call search('^parent ')
           if getline('.') ==# 'parent '


### PR DESCRIPTION
Solves #2448 

This PR adds a third fugitive_display_format to which simply includes `--stat` output in the commit message. Being the 0th display format (handles in the else, rather than an elseif), means that this format will be the default format shown when viewing commits (`:Gedit <rev>`). See appendix[0] for an image of how this looks.

PROBLEMS
   1. - [ ] The `--stat` output is not highlighted by the git parser for treesitter. This would require a PR to the treesitter git parser to solve.
2. - [ ] Display format doesn't appear to be documented in fugitive's docs, this should be added.
3. - [ ] Display format might not be the right way to handle this. Presumably, most users would prefer to always see `--stat` output or to never see `--stat` output. This should probably instead be handled by a config option.
4. - [ ] If display format is to be kept, it should probably not be limited to a given range, rather than be represented as an arbitrary number. 

APPENDIX
[0] - Fugitive `:Gedit` with `--stat` on the left, compared with Neogit's `:NeogitCommit` on the right
<img width="2507" height="1526" alt="536990632-ece03424-976c-447f-ab79-c9d759dc5a24" src="https://github.com/user-attachments/assets/d07cb82f-1624-4711-98c3-191e0221e166" />
