### PR TITLE
Add URLOpen as an alternative in BrowserOpen

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -7443,6 +7443,8 @@ function! s:BrowserOpen(url, mods, echo_copy) abort
     return 'echo '.string(url).'|' . mods . 'Browse '.url
   elseif exists(':OpenBrowser') == 2
     return 'echo '.string(url).'|' . mods . 'OpenBrowser '.url
+  elseif exists(':URLOpen') == 2
+    return 'echo '.string(url).'|' . mods . 'URLOpen '.url
   else
     if !exists('g:loaded_netrw')
       runtime! autoload/netrw.vim


### PR DESCRIPTION
Included in [v9.1.1054](https://github.com/vim/vim/commit/c729d6d154e097b439ff264b9736604824f4a5f4)

Could be another solution to https://github.com/tpope/vim-fugitive/issues/2441