### PR TITLE
Fix foldtext for metadata-only changes and renames

### DIFF
--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -8388,11 +8388,17 @@ function! fugitive#Foldtext() abort
   let line_foldstart = getline(v:foldstart)
   if line_foldstart =~# '^diff '
     let [add, remove] = [-1, -1]
+    let [rename_from, rename_to] = ['', '']
     let filename = ''
     for lnum in range(v:foldstart, v:foldend)
       let line = getline(lnum)
       if filename ==# '' && line =~# '^[+-]\{3\} "\=[abciow12]/'
         let filename = fugitive#Unquote(line[4:-1])[2:-1]
+      endif
+      if line =~# '^rename from '
+        let rename_from = fugitive#Unquote(line[12:-1])
+      elseif line =~# '^rename to '
+        let rename_to = fugitive#Unquote(line[10:-1])
       endif
       if line =~# '^+'
         let add += 1
@@ -8408,7 +8414,9 @@ function! fugitive#Foldtext() abort
     if remove < 0
       let remove = 0
     endif
-    if filename ==# ''
+    if rename_from !=# '' && rename_to !=# ''
+      let filename = rename_from . ' -> ' . rename_to
+    elseif filename ==# ''
       let [old_filename, new_filename] = s:ParseDiffHeader(line_foldstart)
       let filename = new_filename ==# '/dev/null' ? old_filename : new_filename
       let filename = substitute(filename, '^[abciow12]/', '', '')

--- a/autoload/fugitive.vim
+++ b/autoload/fugitive.vim
@@ -8402,8 +8402,16 @@ function! fugitive#Foldtext() abort
         let binary = 1
       endif
     endfor
+    if add < 0
+      let add = 0
+    endif
+    if remove < 0
+      let remove = 0
+    endif
     if filename ==# ''
-      let filename = fugitive#Unquote(matchstr(line_foldstart, '^diff .\{-\} \zs"\=[abciow12]/\zs.*\ze "\=[abciow12]/'))[2:-1]
+      let [old_filename, new_filename] = s:ParseDiffHeader(line_foldstart)
+      let filename = new_filename ==# '/dev/null' ? old_filename : new_filename
+      let filename = substitute(filename, '^[abciow12]/', '', '')
     endif
     if filename ==# ''
       let filename = line_foldstart[5:-1]


### PR DESCRIPTION
`fugitive#Foldtext()` assumes that a file diff contains `---` and `+++` headers. Pure renames and other metadata-only changes omit those headers, so the fold text can report negative counts and a truncated path.

Clamp the counters to zero when file headers are absent, and parse the `diff --git` header to obtain the filename. For renames, use `rename from` and `rename to` metadata so the fold text shows both paths while preserving content-change counts.

Fixes #2388.

## Examples

A pure rename:

```diff
diff --git a/file1 b/file2
similarity index 100%
rename from file1
rename to file2
```

produces:

```text
+--  0+  0- file1 -> file2
```

A rename with one added and one removed line produces:

```text
+--  1+  1- A.md -> B.md
```

A mode-only change:

```diff
diff --git a/script b/script
old mode 100644
new mode 100755
```

produces:

```text
+--  0+  0- script
```
